### PR TITLE
Add option to supply initial value function　#11

### DIFF
--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -548,6 +548,8 @@ end
 """
     solve(cdp, method=PFI; tol=sqrt(eps()), max_iter=500, verbose=2,
           print_skip=50)
+    solve(cdp, method=PFI; v_init, tol=sqrt(eps()), max_iter=500, verbose=2,
+          print_skip=50)
 
 Solve the continuous-state dynamic program
 
@@ -557,6 +559,7 @@ Solve the continuous-state dynamic program
 - `method::Type{T<Algo}(PFI)`: Type name specifying solution method
    Acceptable arguments are 'VFI' for value function iteration or
    'PFI' for policy function iteration. Default solution method is 'PFI'.
+- `v_init::Vector{Float64}`: Initial guess for value function
 - `tol::Real`: Value for epsilon-optimality
 - `max_iter::Int`: Maximum number of iterations
 - `verbose::Int`: Level of feedback (0 for no output, 1 for warnings only, 2 for
@@ -575,6 +578,19 @@ function solve(cdp::ContinuousDP{N,TR,TS}, method::Type{Algo}=PFI;
                print_skip::Int=50) where {Algo<:DPAlgorithm,N,TR,TS}
     tol = Float64(tol)
     res = CDPSolveResult{Algo,N,TR,TS}(cdp, tol, max_iter)
+    _solve!(cdp, res, verbose, print_skip)
+    evaluate!(res)
+    return res
+end
+
+function solve(cdp::ContinuousDP{N,TR,TS}, method::Type{Algo}=PFI;
+               v_init::Vector{Float64}
+               tol::Real=sqrt(eps()), max_iter::Integer=500,
+               verbose::Int=2,
+               print_skip::Int=50) where {Algo<:DPAlgorithm,N,TR,TS}
+    tol = Float64(tol)
+    res = CDPSolveResult{Algo,N,TR,TS}(cdp, tol, max_iter)
+    ldiv!(res.C, cdp.interp.Phi_lu, Tv)
     _solve!(cdp, res, verbose, print_skip)
     evaluate!(res)
     return res

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -546,10 +546,9 @@ end
 #= Solve methods =#
 
 """
-    solve(cdp, method=PFI; tol=sqrt(eps()), max_iter=500, verbose=2,
-          print_skip=50)
-    solve(cdp, method=PFI; v_init, tol=sqrt(eps()), max_iter=500, verbose=2,
-          print_skip=50)
+
+    solve(cdp, method=PFI; v_init=zeros(cdp.interp.length), tol=sqrt(eps()),
+        　max_iter=500, verbose=2,　print_skip=50)
 
 Solve the continuous-state dynamic program
 
@@ -572,25 +571,15 @@ Solve the continuous-state dynamic program
 - `res::CDPSolveResult{Algo,N,TR,TS}`: Object to store the result of dynamic
   programming
 """
-function solve(cdp::ContinuousDP{N,TR,TS}, method::Type{Algo}=PFI;
-               tol::Real=sqrt(eps()), max_iter::Integer=500,
-               verbose::Int=2,
-               print_skip::Int=50) where {Algo<:DPAlgorithm,N,TR,TS}
-    tol = Float64(tol)
-    res = CDPSolveResult{Algo,N,TR,TS}(cdp, tol, max_iter)
-    _solve!(cdp, res, verbose, print_skip)
-    evaluate!(res)
-    return res
-end
 
 function solve(cdp::ContinuousDP{N,TR,TS}, method::Type{Algo}=PFI;
-               v_init::Vector{Float64}
+               v_init::Vector{Float64}=zeros(cdp.interp.length),
                tol::Real=sqrt(eps()), max_iter::Integer=500,
                verbose::Int=2,
                print_skip::Int=50) where {Algo<:DPAlgorithm,N,TR,TS}
     tol = Float64(tol)
     res = CDPSolveResult{Algo,N,TR,TS}(cdp, tol, max_iter)
-    ldiv!(res.C, cdp.interp.Phi_lu, Tv)
+    ldiv!(res.C, cdp.interp.Phi_lu, v_init)
     _solve!(cdp, res, verbose, print_skip)
     evaluate!(res)
     return res


### PR DESCRIPTION
This pull request  provides a new option to supply initial value function in `solve`.
Since Julia does not allow `solve(cdp, method::Type{Algo}=PFI,
               v_init::Vector{Float64}; tol, max_iter, verbose, print_skip)`,  I assign `v_init` to keyword arguments with `zeros(cdp.interp.length)`.

## Detail
1. Users provide an initial guess for value function, `v_init`. (Of course, they don't need to provide this.)
2. Given `v_init`, compute and update basis coefficients `C`.
3. Using this basis coefficients `C`, calculate value function or policy function.


close #11.