### PR TITLE
ENH: Add benchmark suite

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BasisMatrices = "08854c51-b66b-5062-a90d-8e7ae4547a49"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ContinuousDPs = "c470661a-f883-5a79-ade0-a473a39194e2"
+QuantEcon = "fcd29c91-0bd7-5a09-975d-7ac3f643a60c"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,113 @@
+# ContinuousDPs.jl Benchmarks
+
+This directory contains a benchmark suite in the standard
+[BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl) format:
+[`benchmarks.jl`](benchmarks.jl) defines a `BenchmarkGroup` named `SUITE`,
+which can be run standalone or through
+[PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl).
+
+## What is benchmarked
+
+The suite runs three model cases:
+
+- `1d_cheb`: 1-D stochastic optimal growth, Chebyshev basis (50 nodes,
+  9 shock nodes);
+- `1d_spline`: same model, cubic spline basis (101 nodes);
+- `2d_spline`: 2-D stochastic optimal growth with leisure
+  (Santos, 1999, Sec. 7.3; same model as in `test/test_cdp_multidim.jl`),
+  quadratic spline basis (43 × 3 nodes, 7 shock nodes).
+
+For each case, the following are benchmarked:
+
+| Key | Description |
+|:----|:------------|
+| `s_wise_max_one_state` | Per-state maximization kernel `_s_wise_max!` |
+| `bellman_operator` | One application of `bellman_operator!` |
+| `compute_greedy` | One application of `compute_greedy!` |
+| `evaluate_policy` | One application of `evaluate_policy!` |
+| `set_eval_nodes` | Evaluation on a non-interpolation grid |
+| `solve_PFI` | End-to-end `solve` with PFI |
+| `solve_VFI_50iter` | `solve` with VFI, capped at 50 iterations |
+
+Kernel benchmarks use basis coefficients from the converged PFI solution so
+that inputs are realistic. VFI is capped at `max_iter=50` so that the
+benchmark measures a fixed amount of work independently of convergence
+behavior.
+
+## Running the suite standalone
+
+From the repository root, set up the benchmark environment once:
+
+```
+julia --project=benchmark -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
+```
+
+Then run the whole suite (takes a few minutes):
+
+```
+julia --project=benchmark benchmark/benchmarks.jl
+```
+
+To run interactively, e.g., only a subset:
+
+```julia
+julia> include("benchmark/benchmarks.jl");
+
+julia> run(SUITE["1d_cheb"]["bellman_operator"])
+```
+
+## Running with PkgBenchmark.jl
+
+Install PkgBenchmark in your default environment, then, with this package
+active (e.g. `julia --project=.`):
+
+```julia
+using PkgBenchmark
+
+results = benchmarkpkg("ContinuousDPs")
+export_markdown("results.md", results)
+```
+
+### Comparing two commits
+
+To evaluate the performance change of a target commit (or branch) relative
+to a baseline:
+
+```julia
+jud = judge("ContinuousDPs", "<target>", "<baseline>")
+export_markdown("judgement.md", jud)
+```
+
+For example, to compare the current state of `main` against the previous
+commit:
+
+```julia
+jud = judge("ContinuousDPs", "main", "main~1")
+```
+
+Display the judgment summary:
+
+```julia
+julia> show(PkgBenchmark.benchmarkgroup(jud))
+3-element BenchmarkTools.BenchmarkGroup:
+  tags: []
+  "1d_cheb" => 7-element BenchmarkTools.BenchmarkGroup:
+      tags: []
+      "bellman_operator" => TrialJudgement(-35.20% => improvement)
+      "s_wise_max_one_state" => TrialJudgement(-33.87% => improvement)
+      ...
+```
+
+and the timing estimates of each side:
+
+```julia
+julia> show(jud.baseline_results.benchmarkgroup)
+
+julia> show(jud.target_results.benchmarkgroup)
+```
+
+Note that `judge` checks out and runs each commit, so uncommitted changes in
+the working tree are not included.
+
+For comprehensive usage details, refer to the
+[PkgBenchmark documentation](https://juliaci.github.io/PkgBenchmark.jl/stable).

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,155 @@
+#=
+Benchmark suite for ContinuousDPs.jl
+
+Defines `SUITE` in the standard BenchmarkTools format, usable with
+PkgBenchmark.jl or AirspeedVelocity.jl.
+
+To run standalone:
+
+    julia --project=benchmark -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
+    julia --project=benchmark benchmark/benchmarks.jl
+
+Covers the main computational kernels and end-to-end solves:
+- `_s_wise_max!` (per-state optimization kernel)
+- `bellman_operator!` / `compute_greedy!` (state loops over the kernel)
+- `evaluate_policy!` (PFI linear solve)
+- `set_eval_nodes!` (evaluation on non-interpolation grids)
+- end-to-end `solve` with PFI and (iteration-capped) VFI
+=#
+using BenchmarkTools
+using ContinuousDPs
+using ContinuousDPs:
+    _s_wise_max!, bellman_operator!, compute_greedy!, evaluate_policy!
+using BasisMatrices: Basis, ChebParams, SplineParams
+using QuantEcon: qnwlogn, qnwnorm
+
+#= Model definitions =#
+
+# 1-D stochastic optimal growth
+function growth_model_1d(basis)
+    alpha = 0.65
+    f(s, x) = log(x)
+    g(s, x, e) = e * s^alpha - x
+    shocks, weights = qnwlogn(9, 0.0, 0.01)
+    x_lb(s) = 1e-8
+    x_ub(s) = s
+    return ContinuousDP(f, g, 0.95, shocks, weights, x_lb, x_ub, basis)
+end
+
+# 2-D stochastic optimal growth with leisure (Santos, 1999, Sec. 7.3;
+# same model as in test/test_cdp_multidim.jl)
+function growth_model_2d(basis)
+    beta = 0.95
+    lambda = 1 / 3
+    A = 10.0
+    alpha = 0.34
+    delta = 1.0
+    rho = 0.90
+
+    y(k, z, x) = z * A * k^alpha * (1 - x)^(1 - alpha)
+    function c_from_x(k, z, x)
+        term1 = z * A * k^alpha * (1 - x)^(-alpha)
+        term2 = (lambda / (1 - lambda)) * (1 - alpha) * x
+        return term1 * term2
+    end
+    kprime_from_x(k, z, x) = y(k, z, x) + (1 - delta) * k - c_from_x(k, z, x)
+
+    function f(s, x)
+        k, logz = s
+        z = exp(logz)
+        (0 < x < 1) || return -Inf
+        c = c_from_x(k, z, x)
+        kp = kprime_from_x(k, z, x)
+        (c <= 0 || kp < 0) && return -Inf
+        return lambda * log(c) + (1 - lambda) * log(x)
+    end
+
+    function g(s, x, e)
+        k, logz = s
+        z = exp(logz)
+        kp = kprime_from_x(k, z, x)
+        logzp = rho * logz + e
+        return (kp, logzp)
+    end
+
+    shocks, weights = qnwnorm(7, 0.0, 0.008^2)
+    x_lb(s) = 1e-10
+    x_ub(s) = 1 - 1e-10
+    return ContinuousDP(f, g, beta, shocks, weights, x_lb, x_ub, basis)
+end
+
+#= Benchmark cases =#
+
+s_min_1d, s_max_1d = 0.1, 2.0
+k_min, k_max = 0.10, 10.0
+logz_min, logz_max = -0.32, 0.32
+nk, nlogz = 43, 3
+
+cases = [
+    ("1d_cheb", growth_model_1d(Basis(ChebParams(50, s_min_1d, s_max_1d)))),
+    ("1d_spline", growth_model_1d(
+        Basis(SplineParams(99, s_min_1d, s_max_1d, 3)))),
+    ("2d_spline", growth_model_2d(
+        Basis(SplineParams(nk - 1, k_min, k_max, 2),
+              SplineParams(nlogz - 1, logz_min, logz_max, 2)))),
+]
+
+eval_grids = Dict(
+    "1d_cheb" => (collect(range(s_min_1d, s_max_1d, length=500)),),
+    "1d_spline" => (collect(range(s_min_1d, s_max_1d, length=500)),),
+    "2d_spline" => (collect(range(k_min, k_max, length=30)),
+                    collect(range(logz_min, logz_max, length=10))),
+)
+
+#= Suite =#
+
+const SUITE = BenchmarkGroup()
+
+for (label, cdp) in cases
+    grp = SUITE[label] = BenchmarkGroup()
+
+    # End-to-end solves
+    grp["solve_PFI"] = @benchmarkable solve($cdp, PFI; verbose=0)
+    grp["solve_VFI_50iter"] =
+        @benchmarkable solve($cdp, VFI; max_iter=50, verbose=0)
+
+    # Kernel benchmarks at the converged solution, for realistic inputs
+    res = solve(cdp, PFI; verbose=0)
+    C0 = copy(res.C)
+    X0 = copy(res.X)
+    n = cdp.interp.length
+    N = ndims(cdp)
+
+    # Per-state optimization kernel (#73)
+    s_mid = N == 1 ? cdp.interp.S[div(n, 2)] : cdp.interp.S[div(n, 2), :]
+    sp = Matrix{Float64}(undef, size(cdp.shocks, 1), N)
+    grp["s_wise_max_one_state"] =
+        @benchmarkable _s_wise_max!($cdp, $s_mid, $C0, $sp)
+
+    # State loops over the kernel
+    grp["bellman_operator"] = @benchmarkable bellman_operator!(
+        $cdp, C, Tv
+    ) setup = (C = copy($C0); Tv = Vector{Float64}(undef, $n)) evals = 1
+    grp["compute_greedy"] = @benchmarkable compute_greedy!(
+        $cdp, $C0, X
+    ) setup = (X = Vector{Float64}(undef, $n)) evals = 1
+
+    # Policy evaluation: matrix assembly + LU solve (#75)
+    grp["evaluate_policy"] = @benchmarkable evaluate_policy!(
+        $cdp, $X0, C
+    ) setup = (C = Vector{Float64}(undef, $n)) evals = 1
+
+    # Evaluation on a non-interpolation grid (#74)
+    grid = eval_grids[label]
+    grp["set_eval_nodes"] =
+        @benchmarkable set_eval_nodes!($res, $grid...) evals = 1
+end
+
+#= Standalone execution =#
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    tune!(SUITE)
+    results = run(SUITE; verbose=true)
+    show(IOContext(stdout, :compact => false), MIME"text/plain"(), results)
+    println()
+end


### PR DESCRIPTION
## Summary

Add a benchmark suite for the package, so that performance-related PRs can
report standardized before/after comparisons.

- `benchmark/benchmarks.jl`: defines `SUITE` in the standard BenchmarkTools.jl
  format, compatible with PkgBenchmark.jl (and AirspeedVelocity.jl, if we later
  add CI benchmarking)
- `benchmark/Project.toml`: dedicated benchmark environment
- `benchmark/README.md`: usage instructions (standalone and via PkgBenchmark),
  modeled on GameTheory.jl's `benchmark/README.md`

## What is benchmarked

Three model cases — 1-D stochastic optimal growth with Chebyshev and cubic
spline bases, and the 2-D Santos (1999) model from `test/test_cdp_multidim.jl`
with a quadratic spline basis — each with seven benchmarks:

| Key | Description |
|:----|:------------|
| `s_wise_max_one_state` | Per-state maximization kernel `_s_wise_max!` |
| `bellman_operator` | One application of `bellman_operator!` |
| `compute_greedy` | One application of `compute_greedy!` |
| `evaluate_policy` | One application of `evaluate_policy!` |
| `set_eval_nodes` | Evaluation on a non-interpolation grid |
| `solve_PFI` | End-to-end `solve` with PFI |
| `solve_VFI_50iter` | `solve` with VFI, capped at 50 iterations |

Kernel benchmarks use basis coefficients from the converged PFI solution so
inputs are realistic; VFI is capped at 50 iterations so the benchmark measures
a fixed amount of work independently of convergence behavior.

## Baseline (Julia 1.12.6, Apple M4 Pro)

Selected results from a verified `PkgBenchmark.benchmarkpkg` run, to indicate
current allocation behavior:

| ID | time | memory | allocations |
|:---|-----:|-------:|------------:|
| `["1d_cheb", "s_wise_max_one_state"]` | 22.8 μs | 135.6 KiB | 1,102 |
| `["1d_cheb", "bellman_operator"]` | 778.7 μs | 4.4 MiB | 36,452 |
| `["1d_cheb", "solve_VFI_50iter"]` | 182.6 ms | 700.3 MiB | 5,826,322 |
| `["2d_spline", "evaluate_policy"]` | 1.2 ms | 10.3 MiB | 112,496 |
| `["2d_spline", "solve_VFI_50iter"]` | 182.3 ms | 462.0 MiB | 9,305,191 |

## Usage

```julia
using PkgBenchmark
jud = judge("ContinuousDPs", "<target>", "<baseline>")
export_markdown("judgement.md", jud)
```

or standalone: `julia --project=benchmark benchmark/benchmarks.jl`
(see `benchmark/README.md` for details).

## Verification

- Full suite runs cleanly via `benchmarkpkg("ContinuousDPs")` (~1.5 min)
- Standalone execution verified with `--project=benchmark`

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
