### PR TITLE
PERF: Add non-allocating point-evaluation kernel

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -19,7 +19,8 @@ Covers the main computational kernels and end-to-end solves:
 using BenchmarkTools
 using ContinuousDPs
 using ContinuousDPs:
-    _s_wise_max!, bellman_operator!, compute_greedy!, evaluate_policy!
+    _s_wise_max!, bellman_operator!, compute_greedy!, evaluate_policy!,
+    FunEvalCache
 using BasisMatrices: Basis, ChebParams, SplineParams
 using QuantEcon: qnwlogn, qnwnorm
 
@@ -122,9 +123,9 @@ for (label, cdp) in cases
 
     # Per-state optimization kernel (#73)
     s_mid = N == 1 ? cdp.interp.S[div(n, 2)] : cdp.interp.S[div(n, 2), :]
-    sp = Matrix{Float64}(undef, size(cdp.shocks, 1), N)
+    fec = FunEvalCache(cdp.interp.basis)
     grp["s_wise_max_one_state"] =
-        @benchmarkable _s_wise_max!($cdp, $s_mid, $C0, $sp)
+        @benchmarkable _s_wise_max!($cdp, $s_mid, $C0, $fec)
 
     # State loops over the kernel
     grp["bellman_operator"] = @benchmarkable bellman_operator!(

--- a/src/ContinuousDPs.jl
+++ b/src/ContinuousDPs.jl
@@ -10,6 +10,7 @@ import QuantEcon:
 
 const DPAlgorithm = DDPAlgorithm
 
+include("point_eval.jl")
 include("cdp.jl")
 include("lq_approx.jl")
 

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -283,8 +283,13 @@ end
 
 #= Methods =#
 
+# Non-copying access to the i-th point of a set of points stored as a
+# Vector (one point = one scalar) or a Matrix (one point = one row).
+_row(A::AbstractVector, i::Int) = A[i]
+_row(A::AbstractMatrix, i::Int) = view(A, i, :)
+
 """
-    _s_wise_max!(cdp, s, C, sp)
+    _s_wise_max!(cdp, s, C, fec)
 
 Find the optimal value and action at a given state `s`.
 
@@ -293,24 +298,24 @@ Find the optimal value and action at a given state `s`.
 - `cdp::ContinuousDP`: The dynamic program.
 - `s`: State point at which to maximize.
 - `C`: Basis coefficient vector for the value function.
-- `sp::Matrix{Float64}`: Workspace for next-state evaluations.
+- `fec::FunEvalCache`: Workspace for evaluating the value function at the
+  next states.
 
 # Returns
 
 - `v::Float64`: Optimal value at `s`.
 - `x::Float64`: Optimal action at `s`.
 """
-function _s_wise_max!(cdp::ContinuousDP, s, C, sp::Matrix{Float64})
-    shock_tail = Base.tail(axes(cdp.shocks))
-
+function _s_wise_max!(cdp::ContinuousDP, s, C, fec::FunEvalCache)
     function objective(x)
-        for i in 1:size(sp, 1)
-            sp[i, :] .= cdp.g(s, x, cdp.shocks[(i, shock_tail...)...])
+        cont = 0.0
+        for j in eachindex(cdp.weights)
+            e = _row(cdp.shocks, j)
+            s_next = cdp.g(s, x, e)
+            cont += cdp.weights[j] * funeval_point!(fec, C, s_next)
         end
-        Vp = funeval(C, cdp.interp.basis, sp)
-        cont = cdp.discount * dot(cdp.weights, Vp)
         flow = cdp.f(s, x)
-        return flow + cont
+        return flow + cdp.discount * cont
     end
     res = Optim.maximize(objective, cdp.x_lb(s), cdp.x_ub(s))
     v = Optim.maximum(res)::Float64
@@ -334,13 +339,12 @@ Find optimal value for each grid point.
 
 - `Tv::Vector{Float64}`: Updated value function vector.
 """
-function s_wise_max!(cdp::ContinuousDP{N}, ss::AbstractArray{Float64},
-                     C::Vector{Float64}, Tv::Vector{Float64}) where {N}
+function s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+                     C::Vector{Float64}, Tv::Vector{Float64})
     n = size(ss, 1)
-    t = Base.tail(axes(ss))
-    sp = Matrix{Float64}(undef, size(cdp.shocks, 1), N)
+    fec = FunEvalCache(cdp.interp.basis)
     for i in 1:n
-        Tv[i], _ = _s_wise_max!(cdp, ss[(i, t...)...], C, sp)
+        Tv[i], _ = _s_wise_max!(cdp, _row(ss, i), C, fec)
     end
     return Tv
 end
@@ -363,14 +367,13 @@ Find optimal value and action for each grid point.
 - `Tv::Vector{Float64}`: Updated value function vector.
 - `X::Vector{Float64}`: Updated policy function vector.
 """
-function s_wise_max!(cdp::ContinuousDP{N}, ss::AbstractArray{Float64},
+function s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
                      C::Vector{Float64}, Tv::Vector{Float64},
-                     X::Vector{Float64}) where {N}
+                     X::Vector{Float64})
     n = size(ss, 1)
-    t = Base.tail(axes(ss))
-    sp = Matrix{Float64}(undef, size(cdp.shocks, 1), N)
+    fec = FunEvalCache(cdp.interp.basis)
     for i in 1:n
-        Tv[i], X[i] = _s_wise_max!(cdp, ss[(i, t...)...], C, sp)
+        Tv[i], X[i] = _s_wise_max!(cdp, _row(ss, i), C, fec)
     end
     return Tv, X
 end
@@ -440,13 +443,12 @@ Compute the greedy policy for the given basis coefficients.
 
 - `X::Vector{Float64}`: Updated policy function vector.
 """
-function compute_greedy!(cdp::ContinuousDP{N}, ss::AbstractArray{Float64},
-                         C::Vector{Float64}, X::Vector{Float64}) where {N}
+function compute_greedy!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+                         C::Vector{Float64}, X::Vector{Float64})
     n = size(ss, 1)
-    t = Base.tail(axes(ss))
-    sp = Matrix{Float64}(undef, size(cdp.shocks, 1), N)
+    fec = FunEvalCache(cdp.interp.basis)
     for i in 1:n
-        _, X[i] = _s_wise_max!(cdp, ss[(i, t...)...], C, sp)
+        _, X[i] = _s_wise_max!(cdp, _row(ss, i), C, fec)
     end
     return X
 end

--- a/src/point_eval.jl
+++ b/src/point_eval.jl
@@ -1,0 +1,292 @@
+#=
+Non-allocating point evaluation of interpolants on BasisMatrices.jl bases.
+
+Evaluate a fitted function with basis coefficients `C` at a single point
+without constructing `BasisMatrix` objects, using a small preallocated
+workspace. Intended to be lifted upstream to BasisMatrices.jl; this file is
+deliberately self-contained and free of any types defined in ContinuousDPs.
+
+The basis values are computed with exactly the same conventions as
+`BasisMatrices.evalbase`, including the behavior for points outside the
+interpolation domain:
+
+* `ChebParams`: Chebyshev recurrence on the unscaled point (polynomial
+  extrapolation outside `[a, b]`).
+* `SplineParams`: de Boor recurrence on the augmented breakpoint sequence,
+  with the point assigned to the first/last interval outside the domain
+  (i.e., replicating `lookup(augbreaks, x, 3)`).
+* `LinParams`: piecewise linear weights, extrapolated linearly outside the
+  domain.
+
+Only `Float64` coefficients and points are supported, and only the basis
+functions themselves (derivative order 0).
+=#
+using BasisMatrices: BasisParams, ChebParams, SplineParams, LinParams, Basis,
+                     evalbase
+
+#= Per-dimension evaluation caches =#
+
+"""
+    PointEvalCache
+
+Abstract type for one-dimensional basis evaluation caches. A concrete cache
+holds the basis parameters together with a preallocated buffer `vals` for the
+basis function values at a point. See [`point_evalbase!`](@ref).
+"""
+abstract type PointEvalCache end
+
+struct ChebEvalCache{TP<:ChebParams} <: PointEvalCache
+    p::TP
+    vals::Vector{Float64}
+end
+
+struct SplineEvalCache{TP<:SplineParams} <: PointEvalCache
+    p::TP
+    augbreaks::Vector{Float64}
+    numfirst::Int  # lower-endpoint index returned by `lookup(augbreaks, x, 3)`
+    upper::Int     # upper-endpoint index returned by `lookup(augbreaks, x, 3)`
+    vals::Vector{Float64}
+end
+
+struct LinEvalCache{TP<:LinParams} <: PointEvalCache
+    p::TP
+    vals::Vector{Float64}
+end
+
+# Fallback for basis families without a specialized kernel. Correct but slow
+# (allocates): calls `evalbase` with a one-point array.
+struct GenericEvalCache{TP<:BasisParams} <: PointEvalCache
+    p::TP
+    vals::Vector{Float64}
+end
+
+"""
+    PointEvalCache(p::BasisParams)
+
+Construct an evaluation cache for the one-dimensional basis described by `p`.
+Specialized non-allocating kernels are provided for `ChebParams`,
+`SplineParams`, and `LinParams`; other parameter types fall back to a generic
+(allocating) implementation based on `evalbase`.
+"""
+PointEvalCache(p::ChebParams) =
+    ChebEvalCache(p, Vector{Float64}(undef, p.n))
+
+function PointEvalCache(p::SplineParams)
+    k, breaks = p.k, p.breaks
+    augbreaks = convert(
+        Vector{Float64},
+        vcat(fill(breaks[1], k), collect(breaks), fill(breaks[end], k))
+    )
+    m = length(augbreaks)
+    numfirst = 1
+    while numfirst < m && augbreaks[numfirst+1] == augbreaks[1]
+        numfirst += 1
+    end
+    upper = m - 1
+    while upper >= 1 && augbreaks[upper] == augbreaks[m]
+        upper -= 1
+    end
+    return SplineEvalCache(p, augbreaks, numfirst, upper,
+                           Vector{Float64}(undef, k+1))
+end
+
+PointEvalCache(p::LinParams) = LinEvalCache(p, Vector{Float64}(undef, 2))
+
+PointEvalCache(p::BasisParams) =
+    GenericEvalCache(p, Vector{Float64}(undef, length(p)))
+
+# Scalar version of `BasisMatrices.lookup(table, x, 3)` without the endpoint
+# scans (rare branches only).
+@inline function _lookup3(table::AbstractVector, x::Real)
+    m = length(table)
+    ind = searchsortedfirst(table, x) - 1
+    if ind == m
+        i = m - 1
+        while i >= 1 && table[i] == table[m]
+            i -= 1
+        end
+        return i
+    end
+    if ind == 0
+        i = 1
+        while i < m && table[i+1] == table[1]
+            i += 1
+        end
+        return i
+    end
+    return ind
+end
+
+"""
+    point_evalbase!(cache::PointEvalCache, x::Real)
+
+Evaluate the basis functions with nonzero support at the point `x`, storing
+the values in `cache.vals`.
+
+# Returns
+
+- `first::Int`: Index of the first basis function with nonzero support.
+- `nvals::Int`: Number of (potentially) nonzero basis functions;
+  `cache.vals[i]` is the value of basis function `first + i - 1` for
+  `i in 1:nvals`.
+"""
+function point_evalbase!(cache::ChebEvalCache, x::Real)
+    p = cache.p
+    n = p.n
+    vals = cache.vals
+    z = (2 / (p.b - p.a)) * (x - (p.a + p.b) / 2)
+    @inbounds begin
+        vals[1] = 1.0
+        n >= 2 && (vals[2] = z)
+        z2 = 2 * z
+        for j in 3:n
+            vals[j] = z2 * vals[j-1] - vals[j-2]
+        end
+    end
+    return 1, n
+end
+
+function point_evalbase!(cache::SplineEvalCache, x::Real)
+    k = cache.p.k
+    aug = cache.augbreaks
+    vals = cache.vals
+
+    # Interval index, replicating `lookup(augbreaks, x, 3)`
+    ind = searchsortedfirst(aug, x) - 1
+    if ind == length(aug)
+        ind = cache.upper
+    elseif ind == 0
+        ind = cache.numfirst
+    end
+
+    # de Boor recurrence, as in `evalbase(::SplineParams, ...)`
+    @inbounds begin
+        vals[1] = 1.0
+        for j in 2:k+1
+            vals[j] = 0.0
+        end
+        for j in 1:k
+            for jj in j:-1:1
+                b0 = aug[ind+jj-j]
+                b1 = aug[ind+jj]
+                temp = vals[jj] / (b1 - b0)
+                vals[jj+1] = (x - b0) * temp + vals[jj+1]
+                vals[jj] = (b1 - x) * temp
+            end
+        end
+    end
+    return ind - k, k + 1
+end
+
+function point_evalbase!(cache::LinEvalCache, x::Real)
+    p = cache.p
+    breaks = p.breaks
+    n = length(breaks)
+    if p.evennum != 0
+        step_inv = (n - 1) / (breaks[end] - breaks[1])
+        ind = clamp(trunc(Int, (x - breaks[1]) * step_inv) + 1, 1, n-1)
+    else
+        ind = _lookup3(breaks, x)
+    end
+    @inbounds begin
+        z = (x - breaks[ind]) / (breaks[ind+1] - breaks[ind])
+        cache.vals[1] = 1 - z
+        cache.vals[2] = z
+    end
+    return ind, 2
+end
+
+function point_evalbase!(cache::GenericEvalCache, x::Real)
+    B = evalbase(cache.p, [x], 0)
+    n = length(cache.vals)
+    for j in 1:n
+        cache.vals[j] = B[1, j]
+    end
+    return 1, n
+end
+
+
+#= N-dimensional interpolant evaluation =#
+
+"""
+    FunEvalCache{N,TE}
+
+Workspace for evaluating an interpolant on an `N`-dimensional tensor-product
+`Basis` at a single point without allocations. Construct with
+`FunEvalCache(basis)` and evaluate with [`funeval_point!`](@ref).
+
+Not thread-safe: use one cache per thread.
+"""
+struct FunEvalCache{N,TE<:NTuple{N,PointEvalCache}}
+    caches::TE
+    dims::NTuple{N,Int}
+    strides::NTuple{N,Int}
+end
+
+"""
+    FunEvalCache(basis::Basis{N})
+
+Construct a point-evaluation workspace for `basis`.
+"""
+function FunEvalCache(basis::Basis{N}) where N
+    caches = ntuple(d -> PointEvalCache(basis.params[d]), Val(N))
+    dims = ntuple(d -> length(basis.params[d]), Val(N))
+    strides = ntuple(d -> prod(dims[1:d-1]), Val(N))
+    return FunEvalCache(caches, dims, strides)
+end
+
+@inline _coord(x::Real, d::Int) = x
+@inline _coord(x, d::Int) = @inbounds x[d]
+
+"""
+    funeval_point!(fec::FunEvalCache{N}, C, x) -> Float64
+
+Evaluate the interpolant with basis coefficients `C` at the single point `x`,
+using (and overwriting) the workspace `fec`. Equivalent to
+`funeval(C, basis, x)` from BasisMatrices.jl, but non-allocating.
+
+# Arguments
+
+- `fec::FunEvalCache{N}`: Workspace constructed from the same `Basis` that
+  `C` was fitted on.
+- `C::AbstractVector`: Basis coefficient vector, in the same (expanded)
+  ordering used by `funeval`.
+- `x`: Evaluation point: a `Real` if `N == 1`, otherwise anything indexable
+  of length `N` (e.g. `Tuple`, `AbstractVector`).
+
+# Returns
+
+- `::Float64`: Value of the interpolant at `x`.
+"""
+function funeval_point!(fec::FunEvalCache{N}, C::AbstractVector, x) where N
+    firsts_nvals = ntuple(
+        d -> point_evalbase!(fec.caches[d], _coord(x, d)), Val(N)
+    )
+    firsts = map(first, firsts_nvals)
+    nvals = map(last, firsts_nvals)
+    valvecs = ntuple(d -> fec.caches[d].vals, Val(N))
+    strides = fec.strides
+
+    base = 1
+    for d in 1:N
+        base += (firsts[d] - 1) * strides[d]
+    end
+
+    vals1 = valvecs[1]
+    nvals1 = nvals[1]
+    acc = 0.0
+    @inbounds for jrest in CartesianIndices(Base.tail(nvals))
+        w = 1.0
+        offset = base
+        for d in 2:N
+            w *= valvecs[d][jrest[d-1]]
+            offset += (jrest[d-1] - 1) * strides[d]
+        end
+        acc1 = 0.0
+        @simd for i in 0:nvals1-1
+            acc1 += vals1[i+1] * C[offset+i]
+        end
+        acc += w * acc1
+    end
+    return acc
+end

--- a/src/point_eval.jl
+++ b/src/point_eval.jl
@@ -18,8 +18,12 @@ interpolation domain:
 * `LinParams`: piecewise linear weights, extrapolated linearly outside the
   domain.
 
-Only `Float64` coefficients and points are supported, and only the basis
-functions themselves (derivative order 0).
+The kernels work in `Float64` internally: evaluation points are accepted as
+`Real` and converted to `Float64`, while basis coefficients are required to
+be `Float64` (so that unintended use with other numeric types, e.g.
+`BigFloat` or AD dual numbers, fails at dispatch instead of silently losing
+precision). Only the basis functions themselves are evaluated (derivative
+order 0).
 =#
 using BasisMatrices: BasisParams, ChebParams, SplineParams, LinParams, Basis,
                      evalbase
@@ -95,8 +99,8 @@ PointEvalCache(p::LinParams) = LinEvalCache(p, Vector{Float64}(undef, 2))
 PointEvalCache(p::BasisParams) =
     GenericEvalCache(p, Vector{Float64}(undef, length(p)))
 
-# Scalar version of `BasisMatrices.lookup(table, x, 3)` without the endpoint
-# scans (rare branches only).
+# Scalar version of `BasisMatrices.lookup(table, x, 3)`; the scans for
+# repeated endpoint values run only in the rare out-of-range branches.
 @inline function _lookup3(table::AbstractVector, x::Real)
     m = length(table)
     ind = searchsortedfirst(table, x) - 1
@@ -249,8 +253,8 @@ using (and overwriting) the workspace `fec`. Equivalent to
 
 - `fec::FunEvalCache{N}`: Workspace constructed from the same `Basis` that
   `C` was fitted on.
-- `C::AbstractVector`: Basis coefficient vector, in the same (expanded)
-  ordering used by `funeval`.
+- `C::AbstractVector{Float64}`: Basis coefficient vector, in the same
+  (expanded) ordering used by `funeval`.
 - `x`: Evaluation point: a `Real` if `N == 1`, otherwise anything indexable
   of length `N` (e.g. `Tuple`, `AbstractVector`).
 
@@ -258,7 +262,8 @@ using (and overwriting) the workspace `fec`. Equivalent to
 
 - `::Float64`: Value of the interpolant at `x`.
 """
-function funeval_point!(fec::FunEvalCache{N}, C::AbstractVector, x) where N
+function funeval_point!(fec::FunEvalCache{N}, C::AbstractVector{Float64},
+                        x) where N
     firsts_nvals = ntuple(
         d -> point_evalbase!(fec.caches[d], _coord(x, d)), Val(N)
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using BasisMatrices: Basis, ChebParams, SplineParams, LinParams, nodes
 using Test
 using Random
 
+include("test_point_eval.jl")
 include("test_cdp.jl")
 include("test_lq_approx.jl")
 include("test_cdp_multidim.jl")

--- a/test/test_point_eval.jl
+++ b/test/test_point_eval.jl
@@ -1,0 +1,79 @@
+using BasisMatrices: funeval
+using ContinuousDPs: FunEvalCache, funeval_point!
+
+@testset "point_eval.jl" begin
+    rng = MersenneTwister(0)
+
+    # Evaluation points relative to a domain [a, b]: interior points,
+    # breakpoints/endpoints, and points outside the domain
+    function eval_points(a, b, breaks=Float64[])
+        interior = collect(range(a, stop=b, length=17))[2:2:end]
+        vcat(interior, breaks, [a, b, a - 0.1, b + 0.1, a - 2.5, b + 2.5])
+    end
+
+    @testset "1d agreement with funeval: $label" for (label, p) in [
+        ("Cheb", ChebParams(10, -1.5, 2.5)),
+        ("Spline k=1", SplineParams(13, -1.5, 2.5, 1)),
+        ("Spline k=2", SplineParams(13, -1.5, 2.5, 2)),
+        ("Spline k=3", SplineParams(13, -1.5, 2.5, 3)),
+        ("Spline uneven breaks",
+         SplineParams([-1.5, -1.2, -0.3, 0., 0.7, 1.9, 2.5], 0, 3)),
+        ("Lin", LinParams(11, -1.5, 2.5)),
+        ("Lin evennum", LinParams([-1.5, 2.5], 11)),
+        ("Lin uneven breaks", LinParams([-1.5, -1.2, -0.3, 0., 0.7, 2.5], 0)),
+    ]
+        basis = Basis(p)
+        C = randn(rng, length(basis))
+        fec = FunEvalCache(basis)
+        brks = hasproperty(p, :breaks) ? collect(Float64, p.breaks) : Float64[]
+        for x in eval_points(min(basis)[1], max(basis)[1], brks)
+            expected = funeval(C, basis, x)
+            @test funeval_point!(fec, C, x) ≈ expected atol=1e-12 rtol=1e-10
+        end
+    end
+
+    @testset "Nd agreement with funeval: $label" for (label, basis) in [
+        ("Cheb x Cheb",
+         Basis(ChebParams(8, 0.1, 2.), ChebParams(5, -1., 1.))),
+        ("Spline x Spline",
+         Basis(SplineParams(10, 0.1, 2., 3), SplineParams(7, -1., 1., 2))),
+        ("Cheb x Spline",
+         Basis(ChebParams(8, 0.1, 2.), SplineParams(7, -1., 1., 3))),
+        ("Lin x Spline",
+         Basis(LinParams(9, 0.1, 2.), SplineParams(7, -1., 1., 3))),
+        ("Spline x Cheb x Lin",
+         Basis(SplineParams(6, 0.1, 2., 3), ChebParams(4, -1., 1.),
+               LinParams(5, 0., 1.))),
+    ]
+        N = ndims(basis)
+        C = randn(rng, length(basis))
+        fec = FunEvalCache(basis)
+        lb, ub = min(basis), max(basis)
+        points = [ntuple(d -> lb[d] + t * (ub[d] - lb[d]), N)
+                  for t in [-0.2, 0., 0.13, 0.5, 0.77, 1., 1.2]]
+        for x in points
+            expected = funeval(C, basis, collect(x))
+            # point as a Tuple
+            @test funeval_point!(fec, C, x) ≈ expected atol=1e-12 rtol=1e-10
+            # point as a Vector
+            @test funeval_point!(fec, C, collect(x)) ≈ expected atol=1e-12 rtol=1e-10
+        end
+    end
+
+    @testset "non-allocating" begin
+        alloc_after_warmup(fec, C, x) =
+            (funeval_point!(fec, C, x); @allocated funeval_point!(fec, C, x))
+
+        for (basis, x) in [
+            (Basis(ChebParams(10, -1.5, 2.5)), 0.7),
+            (Basis(SplineParams(13, -1.5, 2.5, 3)), 0.7),
+            (Basis(LinParams(11, -1.5, 2.5)), 0.7),
+            (Basis(ChebParams(8, 0.1, 2.), SplineParams(7, -1., 1., 3)),
+             (0.7, 0.2)),
+        ]
+            C = randn(rng, length(basis))
+            fec = FunEvalCache(basis)
+            @test alloc_after_warmup(fec, C, x) == 0
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Add a non-allocating single-point interpolant evaluation kernel and use it in
the inner loop of `_s_wise_max!`, eliminating essentially all allocations from
the optimization step of `bellman_operator!`/`compute_greedy!`.
Addresses #73, and removes most of the cost behind #74.

Previously, each objective-function call inside `Optim.maximize` invoked
`funeval`, which constructs `BasisMatrix` objects at the shock points from
scratch — repeated ~30–40 times per state per operator application.

- `src/point_eval.jl` (new): `PointEvalCache` per-dimension evaluators
  (Chebyshev recurrence, de Boor for splines, piecewise-linear weights, and a
  generic `evalbase` fallback for other basis families), plus
  `FunEvalCache`/`funeval_point!` for evaluating an interpolant on an
  N-dimensional tensor-product `Basis` at a single point with zero
  allocations. The file is self-contained (no DP-specific types) and mirrors
  `BasisMatrices.evalbase` conventions exactly, including behavior outside
  the interpolation domain — the intent is to lift it upstream to
  BasisMatrices.jl later (tracking issue to follow).
- `src/cdp.jl`: `_s_wise_max!` evaluates the continuation value
  `Σⱼ wⱼ V̂(g(s, x, eⱼ))` through the kernel; the `sp` workspace matrix is
  replaced by a `FunEvalCache` constructed once per sweep. Row extraction
  from state/shock arrays uses views instead of copies.
- `test/test_point_eval.jl` (new): 260 tests asserting agreement with
  `funeval` across basis families (Cheb, splines of degree 1–3 with even and
  uneven breaks, Lin with `evennum` 0 and nonzero), mixed 2-D/3-D tensor
  bases, points at/inside/outside the domain boundaries, plus
  zero-allocation assertions.

## Benchmarks (Julia 1.12.6, Apple M4 Pro)

Full `PkgBenchmark.benchmarkpkg` runs on `main` vs. this branch:

| ID | main | this PR |
|:---|---:|---:|
| `["1d_cheb", "s_wise_max_one_state"]` | 22.8 μs, 135.6 KiB, 1,102 allocs | 7.7 μs, 144 B, 2 allocs |
| `["1d_cheb", "bellman_operator"]` | 778.7 μs, 4.4 MiB, 36,452 | 396.1 μs, 7.5 KiB, 102 |
| `["1d_cheb", "solve_PFI"]` | 24.8 ms, 114.1 MiB, 928,640 | 6.6 ms, 11.0 MiB, 78,130 |
| `["1d_cheb", "solve_VFI_50iter"]` | 182.6 ms, 700.3 MiB, 5,826,322 | 86.4 ms, 434.2 KiB, 5,372 |
| `["1d_cheb", "set_eval_nodes"]` | 9.6 ms, 42.6 MiB, 352,620 | 4.1 ms, 336.8 KiB, 1,070 |
| `["1d_spline", "solve_VFI_50iter"]` | 79.6 ms, 277.9 MiB, 4,775,734 | 30.3 ms, 890.5 KiB, 11,002 |
| `["2d_spline", "bellman_operator"]` | 2.9 ms, 8.7 MiB, 174,588 | 1.1 ms, 19.6 KiB, 279 |
| `["2d_spline", "solve_VFI_50iter"]` | 182.3 ms, 462.0 MiB, 9,305,191 | 61.4 ms, 1.1 MiB, 14,453 |

Notes:

- The remaining 144 B / 2 allocations per state are `Optim.maximize`'s
  result object — the evaluation path itself is allocation-free.
- `evaluate_policy` is intentionally untouched; that is #75.
- Remaining per-sweep buffers will be consolidated into a solver-level
  workspace in a follow-up PR.

## Verification

- Full test suite passes (366 tests, including the 260 new ones).
- `@inferred solve(...)` tests continue to pass for both 1-D and 2-D models.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
