### PR TITLE
ENH: Add derivative point evaluation via coefficient differentiation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 QuantEcon = "fcd29c91-0bd7-5a09-975d-7ac3f643a60c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BasisMatrices = "0.8"
@@ -17,4 +18,5 @@ LinearAlgebra = "1"
 Optim = "1, 2"
 QuantEcon = "0.16, 0.17"
 Random = "1"
+SparseArrays = "1"
 julia = "1.10"

--- a/src/point_eval.jl
+++ b/src/point_eval.jl
@@ -22,11 +22,20 @@ The kernels work in `Float64` internally: evaluation points are accepted as
 `Real` and converted to `Float64`, while basis coefficients are required to
 be `Float64` (so that unintended use with other numeric types, e.g.
 `BigFloat` or AD dual numbers, fails at dispatch instead of silently losing
-precision). Only the basis functions themselves are evaluated (derivative
-order 0).
+precision).
+
+Derivatives of the interpolant are supported through coefficient
+differentiation ([`DerivFunEvalCache`](@ref)): for each basis family, the
+derivative of an interpolant is itself an interpolant on the differentiated
+parameters (`derivative_op` from BasisMatrices.jl provides both the sparse
+coefficient operator and the differentiated parameters), so a partial
+derivative is evaluated with the same order-0 kernels after a single sparse
+transformation of the coefficient vector.
 =#
 using BasisMatrices: BasisParams, ChebParams, SplineParams, LinParams, Basis,
-                     evalbase
+                     evalbase, derivative_op
+using LinearAlgebra: I, mul!
+using SparseArrays: SparseMatrixCSC, sparse
 
 #= Per-dimension evaluation caches =#
 
@@ -295,3 +304,86 @@ function funeval_point!(fec::FunEvalCache{N}, C::AbstractVector{Float64},
     end
     return acc
 end
+
+
+#= Point evaluation of derivatives =#
+
+# Differentiated parameters and the composed 1-D coefficient operator for a
+# derivative of order `o` (identity for o == 0)
+function _deriv_params_op(p::BasisParams, o::Int)
+    o == 0 && return p, sparse(1.0I, length(p), length(p))
+    D, p_new = derivative_op(p, [0.0], o)
+    return p_new, SparseMatrixCSC{Float64,Int}(D[o])
+end
+
+function _deriv_params_op(p::SplineParams, o::Int)
+    o == 0 && return p, sparse(1.0I, length(p), length(p))
+    # `evalbase` requires the derivative order to be less than the spline
+    # degree; mirror that restriction here
+    o < p.k || throw(ArgumentError(
+        "derivative order ($o) must be less than the spline degree ($(p.k))"))
+    D, p_new = derivative_op(p, [0.0], o)
+    return p_new, SparseMatrixCSC{Float64,Int}(D[o])
+end
+
+"""
+    DerivFunEvalCache{N,TF}
+
+Workspace for evaluating a partial derivative of an interpolant on an
+`N`-dimensional tensor-product `Basis` at single points without allocations.
+
+The derivative of the interpolant is represented as an interpolant on the
+differentiated basis parameters, whose coefficients are a (sparse) linear
+transformation of the original ones. Set the coefficients with
+[`set_coefs!`](@ref) (once for each new coefficient vector), then evaluate
+with `funeval_point!(dfec, x)` at any number of points.
+
+Not thread-safe: use one cache per thread.
+"""
+struct DerivFunEvalCache{N,TF<:FunEvalCache{N}}
+    order::NTuple{N,Int}
+    fec::TF
+    D::SparseMatrixCSC{Float64,Int}
+    C_deriv::Vector{Float64}
+end
+
+"""
+    DerivFunEvalCache(basis::Basis{N}, order::NTuple{N,Int})
+
+Construct a point-evaluation workspace for the partial derivative of orders
+`order` (one nonnegative integer per dimension, `0` meaning no
+differentiation) of interpolants on `basis`. For `SplineParams`, the order
+must be less than the spline degree, as in `evalbase`.
+"""
+function DerivFunEvalCache(basis::Basis{N}, order::NTuple{N,Int}) where N
+    all(o -> o >= 0, order) ||
+        throw(ArgumentError("derivative orders must be nonnegative"))
+    params_ops = ntuple(d -> _deriv_params_op(basis.params[d], order[d]),
+                        Val(N))
+    fec = FunEvalCache(Basis(map(first, params_ops)))
+    D = reduce(kron, (params_ops[d][2] for d in N:-1:1))
+    C_deriv = Vector{Float64}(undef, size(D, 1))
+    return DerivFunEvalCache(order, fec, D, C_deriv)
+end
+
+"""
+    set_coefs!(dfec::DerivFunEvalCache, C)
+
+Set the basis coefficients of the interpolant to differentiate: transform
+`C` into the coefficients of the derivative interpolant, stored in `dfec`.
+Call once whenever `C` changes, before evaluating with `funeval_point!`.
+"""
+function set_coefs!(dfec::DerivFunEvalCache, C::AbstractVector{Float64})
+    mul!(dfec.C_deriv, dfec.D, C)
+    return dfec
+end
+
+"""
+    funeval_point!(dfec::DerivFunEvalCache, x) -> Float64
+
+Evaluate the partial derivative of the interpolant whose coefficients were
+set by [`set_coefs!`](@ref) at the single point `x`. Equivalent to `funeval`
+with the corresponding derivative `order`, but non-allocating.
+"""
+funeval_point!(dfec::DerivFunEvalCache, x) =
+    funeval_point!(dfec.fec, dfec.C_deriv, x)

--- a/test/test_point_eval.jl
+++ b/test/test_point_eval.jl
@@ -1,5 +1,6 @@
-using BasisMatrices: funeval
-using ContinuousDPs: FunEvalCache, funeval_point!
+using BasisMatrices: funeval, evalbase
+using ContinuousDPs: FunEvalCache, DerivFunEvalCache, funeval_point!,
+                     set_coefs!
 
 @testset "point_eval.jl" begin
     rng = MersenneTwister(0)
@@ -60,6 +61,76 @@ using ContinuousDPs: FunEvalCache, funeval_point!
         end
     end
 
+    # Reference: expanded derivative basis row built from per-dimension
+    # `evalbase` calls. (`funeval` itself cannot serve as the reference for
+    # all cases: its `Direct`/`SplineSparse` path errors for `LinParams`
+    # derivatives, while the dense `evalbase` supports them.)
+    function funeval_deriv(C, basis, x, order)
+        N = ndims(basis)
+        B = reduce(kron,
+                   [Matrix(evalbase(basis.params[d], [Float64(x[d])],
+                                    order[d]))
+                    for d in N:-1:1])
+        return (B * C)[1]
+    end
+
+    @testset "derivative agreement with funeval: $label" for (label, basis, orders) in [
+        ("Cheb",
+         Basis(ChebParams(10, -1.5, 2.5)), [(1,), (2,)]),
+        ("Spline k=2",
+         Basis(SplineParams(13, -1.5, 2.5, 2)), [(1,)]),
+        ("Spline k=3",
+         Basis(SplineParams(13, -1.5, 2.5, 3)), [(1,), (2,)]),
+        ("Spline uneven breaks",
+         Basis(SplineParams([-1.5, -1.2, -0.3, 0., 0.7, 1.9, 2.5], 0, 3)),
+         [(1,), (2,)]),
+        ("Lin",
+         Basis(LinParams(11, -1.5, 2.5)), [(1,)]),
+        ("Cheb x Spline",
+         Basis(ChebParams(8, 0.1, 2.), SplineParams(7, -1., 1., 3)),
+         [(1, 0), (0, 1), (1, 1), (2, 0)]),
+        ("Spline x Spline",
+         Basis(SplineParams(10, 0.1, 2., 3), SplineParams(7, -1., 1., 2)),
+         [(1, 0), (0, 1), (1, 1)]),
+        ("Spline x Cheb x Lin",
+         Basis(SplineParams(6, 0.1, 2., 3), ChebParams(4, -1., 1.),
+               LinParams(5, 0., 1.)),
+         [(1, 0, 0), (0, 1, 1)]),
+    ]
+        N = ndims(basis)
+        C = randn(rng, length(basis))
+        lb, ub = min(basis), max(basis)
+        points = [ntuple(d -> lb[d] + t * (ub[d] - lb[d]), N)
+                  for t in [-0.1, 0., 0.13, 0.5, 0.77, 1., 1.1]]
+        for order in orders
+            dfec = DerivFunEvalCache(basis, order)
+            set_coefs!(dfec, C)
+            for x in points
+                expected = funeval_deriv(C, basis, x, order)
+                @test funeval_point!(dfec, N == 1 ? x[1] : x) ≈ expected atol=1e-10 rtol=1e-9
+            end
+        end
+    end
+
+    @testset "derivative cache: set_coefs! updates" begin
+        basis = Basis(ChebParams(10, -1.5, 2.5))
+        dfec = DerivFunEvalCache(basis, (1,))
+        C1, C2 = randn(rng, 10), randn(rng, 10)
+        set_coefs!(dfec, C1)
+        v1 = funeval_point!(dfec, 0.7)
+        set_coefs!(dfec, C2)
+        @test funeval_point!(dfec, 0.7) ≈ funeval_deriv(C2, basis, (0.7,), (1,))
+        set_coefs!(dfec, C1)
+        @test funeval_point!(dfec, 0.7) == v1
+    end
+
+    @testset "derivative cache: argument errors" begin
+        @test_throws ArgumentError DerivFunEvalCache(
+            Basis(SplineParams(13, -1.5, 2.5, 3)), (3,))  # order == degree
+        @test_throws ArgumentError DerivFunEvalCache(
+            Basis(ChebParams(10, -1.5, 2.5)), (-1,))
+    end
+
     @testset "non-allocating" begin
         alloc_after_warmup(fec, C, x) =
             (funeval_point!(fec, C, x); @allocated funeval_point!(fec, C, x))
@@ -75,5 +146,13 @@ using ContinuousDPs: FunEvalCache, funeval_point!
             fec = FunEvalCache(basis)
             @test alloc_after_warmup(fec, C, x) == 0
         end
+
+        # derivative evaluation is also non-allocating (after set_coefs!)
+        alloc_deriv_after_warmup(dfec, x) =
+            (funeval_point!(dfec, x); @allocated funeval_point!(dfec, x))
+        basis = Basis(ChebParams(8, 0.1, 2.), SplineParams(7, -1., 1., 3))
+        dfec = DerivFunEvalCache(basis, (0, 1))
+        set_coefs!(dfec, randn(rng, length(basis)))
+        @test alloc_deriv_after_warmup(dfec, (0.7, 0.2)) == 0
     end
 end


### PR DESCRIPTION
## Summary

Extend the point-evaluation kernel (#93) to partial derivatives of the interpolant, as preparation for derivative-based inner optimization (#7, #73) and as part of the functionality proposed for upstreaming (#94, QuantEcon/BasisMatrices.jl#82).

Rather than adding per-point derivative recurrences, derivatives are obtained by coefficient differentiation: for each basis family, the derivative of an interpolant is itself an interpolant on the differentiated parameters (Chebyshev of degree `n-1`, spline of degree `k-1`, piecewise linear on midpoints), with coefficients given by a sparse linear operator — both provided by `BasisMatrices.derivative_op`. This is the same construction `evalbase` uses internally, so agreement with BasisMatrices is by construction, and the already-tested order-0 kernels are reused verbatim.

- `DerivFunEvalCache(basis, order::NTuple{N,Int})`: workspace for the partial derivative of orders `order` (one per dimension; mixed and higher orders supported, e.g. `(1, 1)` or `(2, 0)`). For `SplineParams` the order must be less than the spline degree, mirroring `evalbase`'s restriction.
- `set_coefs!(dfec, C)`: transforms the coefficients with a single precomputed sparse matvec (`kron` of the per-dimension operators); call once whenever `C` changes (e.g. once per sweep in a solver).
- `funeval_point!(dfec, x)`: non-allocating single-point evaluation of the derivative interpolant.
- `Project.toml`: add the `SparseArrays` stdlib dependency.

No solver code is touched; this PR is purely additive to `src/point_eval.jl`.

## A BasisMatrices limitation found along the way

`funeval` with derivative orders routes through the `Direct`/`SplineSparse` path, whose `LinParams` method errors with "derivatives un-supported right now" — so BasisMatrices' own `funeval` cannot evaluate `LinParams` derivatives, although the dense `evalbase(p, x, order)` supports them. The agreement tests therefore use the expanded derivative basis row built from per-dimension `evalbase` calls as the reference. Worth mentioning in the QuantEcon/BasisMatrices.jl#82 discussion.

## Verification

- 124 new agreement tests: Cheb (orders 1, 2), splines of degree 2-3 with even and uneven breaks (orders 1, 2), Lin (order 1), and mixed 2-D/3-D tensor bases with gradient, mixed-partial `(1,1)`, and second-order `(2,0)` combinations, at points inside and outside the domain; plus coefficient-update and zero-allocation checks and error cases (spline order >= degree, negative order).
- Full test suite passes (384 point-eval tests total).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
