### PR TITLE
PERF: Assemble the policy-evaluation system with point kernels, sparse when possible

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -150,7 +150,7 @@ for (label, cdp) in cases
 
     # Policy evaluation: matrix assembly + LU solve (#75)
     grp["evaluate_policy"] = @benchmarkable evaluate_policy!(
-        $cdp, $X0, C
+        $cdp, $X0, C, $(ws.fec)
     ) setup = (C = Vector{Float64}(undef, $n)) evals = 1
 
     # Evaluation on a non-interpolation grid (#74)

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -13,6 +13,7 @@ References
 using BasisMatrices
 import Optim
 using FiniteDiff
+using SparseArrays: SparseMatrixCSC, sparse
 import QuantEcon.ScalarOrArray
 
 
@@ -787,8 +788,11 @@ evaluate_policy!(cdp::ContinuousDP, X::Vector{Float64},
                  C::Vector{Float64}) =
     evaluate_policy!(cdp, X, C, FunEvalCache(cdp.interp.basis))
 
-# Basis-function values at the point `x`, as (first column, counts, value
-# buffers, base linear column index) for row assembly
+# Evaluate the per-dimension basis functions at the point `x` (values are
+# left in `fec.caches[d].vals`) and return `(nvals, base)`: the number of
+# nonzero basis functions per dimension, and the linear column index of the
+# tensor-product basis function formed by the first nonzero function of
+# every dimension
 @inline function _basis_row_parts(fec::FunEvalCache{N}, x) where N
     firsts_nvals = ntuple(
         d -> point_evalbase!(fec.caches[d], _coord(x, d)), Val(N)

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -751,45 +751,140 @@ compute_greedy!(cdp::ContinuousDP, C::Vector{Float64}, X::Vector{Float64}) =
     compute_greedy!(cdp, cdp.interp.S, C, X)
 
 """
-    evaluate_policy!(cdp, X, C)
+    evaluate_policy!(cdp, X, C[, fec])
 
-Compute the value function for a given policy and update the basis coefficients.
+Compute the value function for a given policy and update the basis
+coefficients: solve `(Phi - beta * E[Phi(g(S, X, e))]) C = f(S, X)`, where
+the expected-basis matrix is assembled row by row with the non-allocating
+point-evaluation kernels. When the collocation matrix `Phi` is sparse
+(spline and piecewise linear bases), the system matrix is assembled and
+factorized in sparse form.
 
 # Arguments
 
 - `cdp::ContinuousDP`: The dynamic program.
 - `X::Vector{Float64}`: Policy function vector.
 - `C::Vector{Float64}`: A buffer array to hold the basis coefficients.
+- `fec::FunEvalCache`: Workspace whose per-dimension caches are used for
+  basis evaluation at the next states. Constructed internally if not given.
 
 # Returns
 
 - `C::Vector{Float64}`: Updated basis coefficient vector.
 """
-function evaluate_policy!(cdp::ContinuousDP{N}, X::Vector{Float64},
-                          C::Vector{Float64}) where N
-    n = size(cdp.interp.S, 1)
-    ts = Base.tail(axes(cdp.interp.S))
-    te = Base.tail(axes(cdp.shocks))
-    A = Array{Float64}(undef, n, n)
-    A[:] = cdp.interp.Phi
-    for i in 1:n
-        s = cdp.interp.S[(i, ts...)...]
-        for (j, w) in enumerate(cdp.weights)
-            e = cdp.shocks[(j, te...)...]
-            s_next = cdp.g(s, X[i], e)
-            A[i, :] -= ckron(
-                [vec(evalbase(cdp.interp.basis.params[k], s_next[k]))
-                 for k in N:-1:1]...
-            ) * cdp.discount * w
-        end
-    end
-    A_lu = lu(A)
-    for i in 1:n
-        s = cdp.interp.S[(i, ts...)...]
-        C[i] = cdp.f(s, X[i])
+function evaluate_policy!(cdp::ContinuousDP, X::Vector{Float64},
+                          C::Vector{Float64}, fec::FunEvalCache)
+    A_lu = _policy_system_lu(cdp.interp.Phi, cdp, X, fec)
+    ss = cdp.interp.S
+    for i in 1:size(ss, 1)
+        C[i] = cdp.f(_row(ss, i), X[i])
     end
     ldiv!(A_lu, C)
     return C
+end
+
+evaluate_policy!(cdp::ContinuousDP, X::Vector{Float64},
+                 C::Vector{Float64}) =
+    evaluate_policy!(cdp, X, C, FunEvalCache(cdp.interp.basis))
+
+# Basis-function values at the point `x`, as (first column, counts, value
+# buffers, base linear column index) for row assembly
+@inline function _basis_row_parts(fec::FunEvalCache{N}, x) where N
+    firsts_nvals = ntuple(
+        d -> point_evalbase!(fec.caches[d], _coord(x, d)), Val(N)
+    )
+    firsts = map(first, firsts_nvals)
+    nvals = map(last, firsts_nvals)
+    base = 1
+    for d in 1:N
+        base += (firsts[d] - 1) * fec.strides[d]
+    end
+    return nvals, base
+end
+
+# Dense path: A = Phi - beta * E[Phi(g(S, X, e))] assembled in place,
+# factorized with an in-place dense LU
+function _policy_system_lu(Phi::AbstractMatrix, cdp::ContinuousDP, X, fec)
+    n = size(cdp.interp.S, 1)
+    A = copyto!(Matrix{Float64}(undef, n, n), Phi)
+    ss = cdp.interp.S
+    for i in 1:n
+        s = _row(ss, i)
+        for j in eachindex(cdp.weights)
+            e = _row(cdp.shocks, j)
+            s_next = cdp.g(s, X[i], e)
+            _sub_basis_row!(A, i, fec, s_next,
+                            cdp.discount * cdp.weights[j])
+        end
+    end
+    return lu!(A)
+end
+
+# A[i, :] .-= coef * (basis-function values at x), touching only the
+# nonzero entries
+function _sub_basis_row!(A::Matrix{Float64}, i::Int, fec::FunEvalCache{N},
+                         x, coef::Float64) where N
+    nvals, base = _basis_row_parts(fec, x)
+    valvecs = ntuple(d -> fec.caches[d].vals, Val(N))
+    strides = fec.strides
+    vals1 = valvecs[1]
+    nvals1 = nvals[1]
+    @inbounds for jrest in CartesianIndices(Base.tail(nvals))
+        w = coef
+        offset = base
+        for d in 2:N
+            w *= valvecs[d][jrest[d-1]]
+            offset += (jrest[d-1] - 1) * strides[d]
+        end
+        for t in 0:nvals1-1
+            A[i, offset+t] -= w * vals1[t+1]
+        end
+    end
+    return A
+end
+
+# Sparse path: assemble E = E[Phi(g(S, X, e))] in triplet form (exploiting
+# that only few basis functions are nonzero at each point), then factorize
+# A = Phi - beta * E with a sparse LU
+function _policy_system_lu(Phi::SparseMatrixCSC, cdp::ContinuousDP, X, fec)
+    n = size(cdp.interp.S, 1)
+    Is, Js, Vs = Int[], Int[], Float64[]
+    ss = cdp.interp.S
+    for i in 1:n
+        s = _row(ss, i)
+        for j in eachindex(cdp.weights)
+            e = _row(cdp.shocks, j)
+            s_next = cdp.g(s, X[i], e)
+            _append_basis_row!(Is, Js, Vs, i, fec, s_next, cdp.weights[j])
+        end
+    end
+    E = sparse(Is, Js, Vs, n, n)  # sums duplicate entries
+    return lu(Phi - cdp.discount * E)
+end
+
+# Append coef * (basis-function values at x) to the triplets of row i
+function _append_basis_row!(Is::Vector{Int}, Js::Vector{Int},
+                            Vs::Vector{Float64}, i::Int,
+                            fec::FunEvalCache{N}, x, coef::Float64) where N
+    nvals, base = _basis_row_parts(fec, x)
+    valvecs = ntuple(d -> fec.caches[d].vals, Val(N))
+    strides = fec.strides
+    vals1 = valvecs[1]
+    nvals1 = nvals[1]
+    @inbounds for jrest in CartesianIndices(Base.tail(nvals))
+        w = coef
+        offset = base
+        for d in 2:N
+            w *= valvecs[d][jrest[d-1]]
+            offset += (jrest[d-1] - 1) * strides[d]
+        end
+        for t in 0:nvals1-1
+            push!(Is, i)
+            push!(Js, offset + t)
+            push!(Vs, w * vals1[t+1])
+        end
+    end
+    return nothing
 end
 
 
@@ -817,7 +912,7 @@ function policy_iteration_operator!(cdp::ContinuousDP, C::Vector{Float64},
     else
         compute_greedy!(cdp, cdp.interp.S, C, ws.X, ws.fec)
     end
-    evaluate_policy!(cdp, ws.X, C)
+    evaluate_policy!(cdp, ws.X, C, ws.fec)
     return C
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Random
 include("test_point_eval.jl")
 include("test_workspace.jl")
 include("test_foc.jl")
+include("test_evaluate_policy.jl")
 include("test_cdp.jl")
 include("test_lq_approx.jl")
 include("test_cdp_multidim.jl")

--- a/test/test_evaluate_policy.jl
+++ b/test/test_evaluate_policy.jl
@@ -1,0 +1,73 @@
+using BasisMatrices: ckron, evalbase
+using ContinuousDPs: evaluate_policy!, FunEvalCache
+using QuantEcon: qnwnorm
+
+@testset "evaluate_policy!" begin
+    # Reference: the pre-optimization implementation (dense, per-point
+    # evalbase + ckron row updates)
+    function evaluate_policy_ref(cdp, X)
+        N = ndims(cdp)
+        n = size(cdp.interp.S, 1)
+        ts = Base.tail(axes(cdp.interp.S))
+        te = Base.tail(axes(cdp.shocks))
+        A = Array{Float64}(undef, n, n)
+        A[:] = cdp.interp.Phi
+        for i in 1:n
+            s = cdp.interp.S[(i, ts...)...]
+            for (j, w) in enumerate(cdp.weights)
+                e = cdp.shocks[(j, te...)...]
+                s_next = cdp.g(s, X[i], e)
+                A[i, :] -= ckron(
+                    [vec(evalbase(cdp.interp.basis.params[k], s_next[k]))
+                     for k in N:-1:1]...
+                ) * cdp.discount * w
+            end
+        end
+        C = [cdp.f(cdp.interp.S[(i, ts...)...], X[i]) for i in 1:n]
+        return A \ C
+    end
+
+    shocks, weights = qnwnorm(3, 0.0, 0.01)
+
+    @testset "1d: $label" for (label, basis) in [
+        ("Cheb", Basis(ChebParams(15, 0., 1.))),
+        ("Spline k=3", Basis(SplineParams(15, 0., 1., 3))),
+        ("Lin", Basis(LinParams(15, 0., 1.))),
+    ]
+        f(s, x) = log(1 + s + x)
+        g(s, x, e) = clamp(0.5 * s + 0.2 * x + 0.1 * e, 0., 1.)
+        cdp = ContinuousDP(f, g, 0.9, shocks, weights, s -> 0., s -> 1.,
+                           basis)
+        X = [0.25 + 0.5 * s for s in cdp.interp.S]
+        C = Vector{Float64}(undef, cdp.interp.length)
+        evaluate_policy!(cdp, X, C)
+        @test C ≈ evaluate_policy_ref(cdp, X) rtol=1e-9
+        # fec-passing method gives the same result
+        C2 = Vector{Float64}(undef, cdp.interp.length)
+        evaluate_policy!(cdp, X, C2, FunEvalCache(cdp.interp.basis))
+        @test C2 == C
+    end
+
+    @testset "2d: $label" for (label, basis) in [
+        ("Cheb x Cheb",
+         Basis(ChebParams(8, 0., 1.), ChebParams(5, 0., 1.))),
+        ("Spline x Spline",
+         Basis(SplineParams(8, 0., 1., 3), SplineParams(6, 0., 1., 2))),
+        ("Lin x Lin",
+         Basis(LinParams(8, 0., 1.), LinParams(6, 0., 1.))),
+        ("Cheb x Spline",
+         Basis(ChebParams(8, 0., 1.), SplineParams(6, 0., 1., 3))),
+    ]
+        f(s, x) = log(1 + s[1] + s[2] + x)
+        g(s, x, e) = (clamp(0.5 * s[1] + 0.2 * x + 0.1 * e, 0., 1.),
+                      clamp(0.8 * s[2] + 0.1, 0., 1.))
+        cdp = ContinuousDP(f, g, 0.9, shocks, weights, s -> 0., s -> 1.,
+                           basis)
+        n = cdp.interp.length
+        X = [0.25 + 0.25 * (cdp.interp.S[i, 1] + cdp.interp.S[i, 2])
+             for i in 1:n]
+        C = Vector{Float64}(undef, n)
+        evaluate_policy!(cdp, X, C)
+        @test C ≈ evaluate_policy_ref(cdp, X) rtol=1e-9
+    end
+end


### PR DESCRIPTION
## Summary

Rewrite the linear-system assembly in `evaluate_policy!`. Closes #75 — the last of the three performance issues, and after #99 the dominant cost of PFI solves.

Previously, each (state, shock) pair called `evalbase` per dimension, materialized the tensor-product basis row with `ckron`, and subtracted it from a dense copy of `Phi` — allocating temporaries for every one of the `n * m` next states, and destroying sparsity for spline/piecewise-linear bases. Now:

- The basis row at each next state is written directly from the non-allocating point-evaluation kernels (#93): `point_evalbase!` yields exactly the nonzero row segment per dimension, and the tensor product is expanded in place — no `evalbase` matrices, no `ckron`, no row temporaries.
- The path is chosen by the type of the collocation matrix `Phi`. Dense (Chebyshev and mixed-dense bases): in-place row updates into one dense `A`, factorized with `lu!` (saving the extra copy `lu` makes). Sparse (`Phi::SparseMatrixCSC`, i.e. spline and piecewise-linear bases): the expected-basis matrix is assembled in triplet form — only the few nonzero entries per point are ever touched — and `A = Phi - beta * E` is factorized with sparse LU (UMFPACK). For large spline grids this changes the complexity class of the factorization from O(n^3) dense to sparse.
- `evaluate_policy!` gains a `fec::FunEvalCache` argument (the workspace's cache is passed by `policy_iteration_operator!`); the existing 3-argument signature is kept and constructs one internally.

## Benchmarks (Julia 1.12.6, Apple M4 Pro)

Full `PkgBenchmark.benchmarkpkg` runs on `main` vs. this branch:

| ID | main | this PR | speedup |
|:---|---:|---:|---:|
| `["1d_cheb", "evaluate_policy"]` | 108.5 μs, 1.21 MiB, 8,558 allocs | 53.2 μs, 20.6 KiB, 5 allocs | 2.0x |
| `["1d_spline", "evaluate_policy"]` | 738.0 μs, 8.01 MiB, 63,638 allocs | 173.6 μs, 1.12 MiB, 160 allocs | 4.3x |
| `["2d_spline", "evaluate_policy"]` | 1.14 ms, 10.3 MiB, 112,496 allocs | 229.2 μs, 1.27 MiB, 163 allocs | 5.0x |
| `["1d_cheb", "solve_PFI"]` | 2.81 ms, 6.2 MiB | 2.56 ms, 299 KiB | 1.1x |
| `["1d_spline", "solve_PFI"]` | 7.28 ms, 40.1 MiB | 6.32 ms, 5.6 MiB | 1.15x |
| `["2d_spline", "solve_PFI"]` | 20.3 ms, 62.0 MiB | 14.1 ms, 7.8 MiB | 1.44x |

The `2d_spline` PFI regression documented in #99 (21.0 ms vs. 18.8 ms before the FOC solver) is resolved: 14.1 ms is well below both. VFI and `bellman_operator` benchmarks are unchanged (within noise), as `evaluate_policy!` is not on that path. The remaining sparse-path allocations (~160: triplet vectors and the sparse factorization) could be reduced further by reusing the sparsity pattern across PFI iterations, but with the assembly now at ~0.2 ms the returns are small.

## Verification

- New `test/test_evaluate_policy.jl`: the new assembly is compared against a verbatim copy of the previous implementation (dense `evalbase` + `ckron`) at machine precision (`rtol=1e-9`), across seven basis configurations: 1-D Chebyshev/spline/Lin and 2-D Cheb x Cheb, Spline x Spline, Lin x Lin, and mixed Cheb x Spline — the last exercising whichever branch the mixed `Phi` type takes.
- Full test suite passes (all PFI-based model tests run through the new code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
