### PR TITLE
PERF: Reuse result buffers and kernel-based residuals in evaluate!

### DIFF
--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -210,6 +210,10 @@ Base.ndims(::CDPSolveResult{Algo,N}) where {Algo,N} = N
 
 Evaluate the value function and the policy function at the evaluation nodes.
 
+The result arrays `res.V`, `res.X`, and `res.resid` are updated in place
+when their lengths already match the number of evaluation nodes, and
+reallocated otherwise.
+
 # Arguments
 
 - `res::CDPSolveResult`: Solution object to update in place.
@@ -218,8 +222,14 @@ Evaluate the value function and the policy function at the evaluation nodes.
 """
 function evaluate!(res::CDPSolveResult, fec::FunEvalCache)
     cdp, C, s_nodes = res.cdp, res.C, res.eval_nodes
-    res.V, res.X = s_wise_max(cdp, s_nodes, C, fec)
-    res.resid = res.V - vec(funeval(C, cdp.interp.basis, s_nodes))
+    n = size(s_nodes, 1)
+    length(res.V) == n || (res.V = Vector{Float64}(undef, n))
+    length(res.X) == n || (res.X = Vector{Float64}(undef, n))
+    length(res.resid) == n || (res.resid = Vector{Float64}(undef, n))
+    s_wise_max!(cdp, s_nodes, C, res.V, res.X, fec)
+    for i in 1:n
+        res.resid[i] = res.V[i] - funeval_point!(fec, C, _row(s_nodes, i))
+    end
     return res
 end
 
@@ -281,8 +291,13 @@ policy, and `resid` is the Bellman residual at `s_nodes`.
 """
 function (res::CDPSolveResult)(s_nodes::AbstractArray{Float64})
     cdp, C = res.cdp, res.C
-    V, X = s_wise_max(cdp, s_nodes, C)
-    resid = V - vec(funeval(C, cdp.interp.basis, s_nodes))
+    fec = FunEvalCache(cdp.interp.basis)
+    V, X = s_wise_max(cdp, s_nodes, C, fec)
+    n = size(s_nodes, 1)
+    resid = Vector{Float64}(undef, n)
+    for i in 1:n
+        resid[i] = V[i] - funeval_point!(fec, C, _row(s_nodes, i))
+    end
     return V, X, resid
 end
 

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -18,6 +18,36 @@ using ContinuousDPs: CDPWorkspace, bellman_operator!, policy_iteration_operator!
     @test !converged
 end
 
+@testset "evaluate! in-place buffers" begin
+    f(s, x) = log(x)
+    g(s, x, e) = clamp(e * s^0.65 - x, 0.5, 2.0)
+    shocks, weights = qnwnorm(5, 1.0, 0.01)
+    basis = Basis(ChebParams(20, 0.5, 2.0))
+    cdp = ContinuousDP(f, g, 0.95, shocks, weights, s -> 1e-8, s -> s, basis)
+    res = solve(cdp, PFI, verbose=0)
+
+    # Same-length evaluation nodes: the result arrays are reused in place
+    grid1 = collect(range(0.5, 2.0, length=100))
+    set_eval_nodes!(res, grid1)
+    V1, X1, resid1 = res.V, res.X, res.resid
+    grid2 = collect(range(0.6, 1.9, length=100))
+    set_eval_nodes!(res, grid2)
+    @test res.V === V1
+    @test res.X === X1
+    @test res.resid === resid1
+
+    # Different length: reallocated
+    set_eval_nodes!(res, collect(range(0.5, 2.0, length=50)))
+    @test res.V !== V1
+    @test length(res.V) == 50
+
+    # Values agree with the callable interface at the same nodes
+    V, X, resid = res(res.eval_nodes)
+    @test V == res.V
+    @test X == res.X
+    @test resid == res.resid
+end
+
 @testset "CDPWorkspace" begin
     beta = 0.95
     f(s, x) = log(x)


### PR DESCRIPTION
## Summary

Complete the in-place evaluation pathway. Closes #74.

- `evaluate!` now reuses `res.V`, `res.X`, and `res.resid` in place when their lengths already match the number of evaluation nodes (reallocating otherwise), and fills them via the mutating `s_wise_max!` instead of the allocating wrapper.
- The Bellman residual is computed point-wise with `funeval_point!` instead of `res.V - vec(funeval(...))`, removing the batch `BasisMatrix` construction at the evaluation nodes and the two temporary arrays.
- The callable interface `res(s_nodes)` keeps its return-fresh-arrays contract, but internally shares a single `FunEvalCache` and uses the same kernel-based residual computation, so its output remains exactly equal (`==`) to the `res` fields at the same nodes.

Behavior note: after `set_eval_nodes!` with a grid of the *same* length as the current one, the arrays bound to `res.V`/`res.X`/`res.resid` are now mutated rather than replaced — a reference obtained earlier will see the new values. This is the intended in-place semantics (and is now documented in the `evaluate!` docstring); copy the arrays to keep a snapshot.

## Benchmarks (Julia 1.12.6, Apple M4 Pro)

Full `PkgBenchmark.benchmarkpkg` runs on `main` vs. this branch. Times are within noise everywhere (the per-node Brent maximization dominates `set_eval_nodes`); the change is allocation hygiene:

| ID | main | this PR |
|:---|---:|---:|
| `["1d_cheb", "set_eval_nodes"]` | 4.49 ms, 336.8 KiB, 1,070 allocs | 4.50 ms, 70.8 KiB, 1,002 allocs |
| `["1d_spline", "set_eval_nodes"]` | 3.12 ms, 131.9 KiB, 1,098 allocs | 3.10 ms, 72.3 KiB, 1,010 allocs |
| `["2d_spline", "set_eval_nodes"]` | 2.67 ms, 101.3 KiB, 759 allocs | 2.66 ms, 49.1 KiB, 634 allocs |

The remaining ~2 allocations per evaluation node are `Optim.maximize`'s result objects in the Brent-based evaluation sweep — the same floor as elsewhere.

## Verification

- New tests pin the in-place semantics: re-evaluation on a same-length grid preserves array identity (`===`), a different-length grid reallocates, and the results agree exactly with the callable interface.
- Full test suite passes, including the multidim tests' exact-equality comparisons between `res(s_nodes)` and the `res` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
