### PR TITLE
MAINT: Remove the v0.2 API; thread interp explicitly through the internals

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -20,7 +20,7 @@ using BenchmarkTools
 using ContinuousDPs
 using ContinuousDPs:
     _s_wise_max!, bellman_operator!, compute_greedy!, evaluate_policy!,
-    FunEvalCache, CDPWorkspace, DiscreteActions, Interp, _with_interp
+    FunEvalCache, CDPWorkspace, DiscreteActions, Interp, _CollocationProblem
 using BasisMatrices: Basis, ChebParams, SplineParams
 using QuantEcon: qnwlogn, qnwnorm
 
@@ -131,7 +131,7 @@ for (label, cdp, basis) in cases
     # the internal operators work on a problem with a bound interpolation
     # scheme
     res = solve(cdp, solver_pfi; verbose=0)
-    colloc_cdp = _with_interp(cdp, Interp(basis))
+    colloc_cdp = _CollocationProblem(cdp, Interp(basis))
     C0 = copy(res.C)
     X0 = copy(res.X)
     n = colloc_cdp.interp.length
@@ -141,7 +141,7 @@ for (label, cdp, basis) in cases
     s_mid = N == 1 ? colloc_cdp.interp.S[div(n, 2)] : colloc_cdp.interp.S[div(n, 2), :]
     fec = FunEvalCache(colloc_cdp.interp.basis)
     grp["s_wise_max_one_state"] =
-        @benchmarkable _s_wise_max!($colloc_cdp, $s_mid, $C0, $fec)
+        @benchmarkable _s_wise_max!($(colloc_cdp.cdp), $s_mid, $C0, $fec)
 
     # State loops over the kernel, using a preallocated workspace
     ws = CDPWorkspace(colloc_cdp)
@@ -185,7 +185,7 @@ let
     grp["solve_VFI_50iter"] =
         @benchmarkable solve($cdp, $solver_vfi; verbose=0)
     res = solve(cdp, solver_pfi; verbose=0)
-    colloc_cdp = _with_interp(cdp, Interp(basis))
+    colloc_cdp = _CollocationProblem(cdp, Interp(basis))
     C0 = copy(res.C)
     ws = CDPWorkspace(colloc_cdp)
     grp["bellman_operator"] = @benchmarkable bellman_operator!(
@@ -227,7 +227,7 @@ let
     grp["solve_VFI_50iter"] =
         @benchmarkable solve($cdp, $solver_vfi; verbose=0)
     res = solve(cdp, solver_pfi; verbose=0)
-    colloc_cdp = _with_interp(cdp, Interp(basis))
+    colloc_cdp = _CollocationProblem(cdp, Interp(basis))
     C0 = copy(res.C)
     ws = CDPWorkspace(colloc_cdp)
     grp["bellman_operator"] = @benchmarkable bellman_operator!(

--- a/examples/cdp_ex_optgrowth_jl.ipynb
+++ b/examples/cdp_ex_optgrowth_jl.ipynb
@@ -5058,7 +5058,7 @@
     "using ContinuousDPs: bellman_operator!\n",
     "cdp = ContinuousDP(cdp, discount=p.beta)  # Reset `discount` to the original\n",
     "# The internal operators work on a problem with a bound interpolation scheme\n",
-    "colloc_cdp = ContinuousDPs._with_interp(cdp, ContinuousDPs.Interp(basis))\n",
+    "colloc_cdp = ContinuousDPs._CollocationProblem(cdp, ContinuousDPs.Interp(basis))\n",
     "C_star = colloc_cdp.interp.Phi \\ v_star.(colloc_cdp.interp.S; p)\n",
     "Tv = Array{Float64}(undef, colloc_cdp.interp.length)\n",
     "C = copy(C_star)\n",

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -172,7 +172,7 @@ _action_dim(::ContinuousActions{M}) where M = M
 
 
 """
-    ContinuousDP{N,Tf,Tg,TR,TA,TI}
+    ContinuousDP{Tf,Tg,TR,TA}
 
 Type representing a continuous-state dynamic program. A `ContinuousDP` holds
 the primitives of the problem; the interpolation scheme used to solve it is
@@ -188,20 +188,14 @@ and [`LQASolver`](@ref)).
 - `weights::Vector{Float64}`: Probability weights for the shock nodes.
 - `actions::TA<:ActionSpace`: Action space (see [`ContinuousActions`](@ref)
   and [`DiscreteActions`](@ref)).
-- `interp::TI<:Union{Interp{N},Nothing}`: Internal. `nothing` for a
-  primitives-only problem (the normal case; `N == 0` then serves as a
-  placeholder); an `Interp{N}` bound to the problem by `solve` (or by the
-  deprecated basis-endowed constructor).
 """
-struct ContinuousDP{N,Tf,Tg,TR<:AbstractVecOrMat,TA<:ActionSpace,
-                    TI<:Union{Interp{N},Nothing}}
+struct ContinuousDP{Tf,Tg,TR<:AbstractVecOrMat,TA<:ActionSpace}
     f::Tf
     g::Tg
     discount::Float64
     shocks::TR
     weights::Vector{Float64}
     actions::TA
-    interp::TI
 end
 
 """
@@ -230,9 +224,8 @@ Give either `actions`, or both `x_lb` and `x_ub` (equivalent to
 function ContinuousDP(f, g, discount::Real,
                       shocks::AbstractVecOrMat, weights::Vector{Float64},
                       actions::ActionSpace)
-    return ContinuousDP{0,typeof(f),typeof(g),typeof(shocks),
-                        typeof(actions),Nothing}(
-        f, g, Float64(discount), shocks, weights, actions, nothing)
+    return ContinuousDP{typeof(f),typeof(g),typeof(shocks),typeof(actions)}(
+        f, g, Float64(discount), shocks, weights, actions)
 end
 
 ContinuousDP(f, g, discount::Real,
@@ -309,15 +302,28 @@ function ContinuousDP(cdp::ContinuousDP;
 end
 
 
+# Internal: a ContinuousDP bound to an interpolation scheme. All solver
+# internals from the node-sweep level up consume this pair; ContinuousDP
+# itself stays primitives-only. The state-local point kernels
+# (_s_wise_max! and friends) take the plain ContinuousDP: they are
+# interpolation-free by design (they only need a FunEvalCache).
+struct _CollocationProblem{N,TCDP<:ContinuousDP,TI<:Interp{N}}
+    cdp::TCDP
+    interp::TI
+end
+
+Base.ndims(::_CollocationProblem{N}) where {N} = N
+
 """
-    CDPSolveResult{Algo,N,TCDP,TE}
+    CDPSolveResult{Algo,N,TCDP,TI,TE,TX}
 
 Type storing the solution of a continuous-state dynamic program obtained by
 algorithm `Algo`.
 
 # Fields
 
-- `cdp::TCDP<:ContinuousDP{N}`: The dynamic program that was solved.
+- `cdp::TCDP<:ContinuousDP`: The dynamic program that was solved.
+- `interp::TI<:Interp{N}`: The interpolation scheme used by the solver.
 - `tol::Float64`: Convergence tolerance used by the solver.
 - `max_iter::Int`: Maximum number of iterations allowed.
 - `C::Vector{Float64}`: Basis coefficient vector for the fitted value function.
@@ -327,9 +333,9 @@ algorithm `Algo`.
   `:brent`); also used when re-evaluating the policy (e.g. by
   `set_eval_nodes!`) for multi-dimensional continuous actions.
 - `eval_nodes::TE<:VecOrMat`: Nodes at which the solution is evaluated.
-  Defaults to `cdp.interp.S`.
+  Defaults to `interp.S`.
 - `eval_nodes_coord::NTuple{N,Vector{Float64}}`: Coordinate vectors of the
-  evaluation nodes along each dimension. Defaults to `cdp.interp.Scoord`.
+  evaluation nodes along each dimension. Defaults to `interp.Scoord`.
 - `V::Vector{Float64}`: Value function evaluated at `eval_nodes`.
 - `X::TX<:AbstractVecOrMat`: Policy function (action values) evaluated at
   `eval_nodes` (an `n x M` matrix for `M`-dimensional continuous actions).
@@ -337,9 +343,11 @@ algorithm `Algo`.
   `cdp.actions.vals` corresponding to `X`; empty otherwise.
 - `resid::Vector{Float64}`: Approximation residuals at `eval_nodes`.
 """
-mutable struct CDPSolveResult{Algo<:DPAlgorithm,N,TCDP<:ContinuousDP{N},
-                              TE<:VecOrMat,TX<:AbstractVecOrMat}
+mutable struct CDPSolveResult{Algo<:DPAlgorithm,N,TCDP<:ContinuousDP,
+                              TI<:Interp{N},TE<:VecOrMat,
+                              TX<:AbstractVecOrMat}
     cdp::TCDP
+    interp::TI
     tol::Float64
     max_iter::Int
     C::Vector{Float64}
@@ -353,45 +361,34 @@ mutable struct CDPSolveResult{Algo<:DPAlgorithm,N,TCDP<:ContinuousDP{N},
     X_ind::Vector{Int}
     resid::Vector{Float64}
 
-    function CDPSolveResult{Algo,N}(
-            cdp::TCDP, tol::Float64, max_iter::Integer,
+    function CDPSolveResult{Algo}(
+            cdp::TCDP, interp::Interp{N}, tol::Float64, max_iter::Integer,
             inner_solver::Symbol=:foc
-        ) where {Algo,N,TCDP<:ContinuousDP{N}}
-        C = zeros(cdp.interp.length)
+        ) where {Algo,N,TCDP<:ContinuousDP}
+        C = zeros(interp.length)
         converged = false
         num_iter = 0
-        eval_nodes = cdp.interp.S
-        eval_nodes_coord = cdp.interp.Scoord
+        eval_nodes = interp.S
+        eval_nodes_coord = interp.Scoord
         V = Float64[]
         X = _empty_policy(cdp.actions)
         X_ind = Int[]
         resid = Float64[]
-        res = new{Algo,N,TCDP,typeof(eval_nodes),typeof(X)}(
-            cdp, tol, max_iter, C, converged, num_iter, inner_solver,
+        res = new{Algo,N,TCDP,typeof(interp),typeof(eval_nodes),typeof(X)}(
+            cdp, interp, tol, max_iter, C, converged, num_iter, inner_solver,
             eval_nodes, eval_nodes_coord, V, X, X_ind, resid
         )
         return res
     end
 end
 
-Base.ndims(::ContinuousDP{N}) where {N} = N
-Base.ndims(::ContinuousDP{0}) = throw(ArgumentError(
-    "the state dimension of a primitives-only ContinuousDP is determined " *
-    "by the basis of the solver passed to `solve`"))
-
-# Bind an interpolation scheme to (a copy of) the problem's primitives.
-# Fully explicit type parameters: the implicit constructor cannot infer `N`
-# when `TI` is `Nothing`, so it is never relied upon here.
-_with_interp(cdp::ContinuousDP, interp::Interp{N}) where {N} =
-    ContinuousDP{N,typeof(cdp.f),typeof(cdp.g),typeof(cdp.shocks),
-                 typeof(cdp.actions),typeof(interp)}(
-        cdp.f, cdp.g, cdp.discount, cdp.shocks, cdp.weights, cdp.actions,
-        interp)
+# Rebuild the internal bound problem from a result
+_colloc(res::CDPSolveResult) = _CollocationProblem(res.cdp, res.interp)
 
 # Derivative caches for gradient-based evaluation sweeps, or nothing when
 # the basis does not support them (then the derivative-free path is used)
-function _eval_dfecs(cdp::ContinuousDP{N}) where N
-    basis = cdp.interp.basis
+function _eval_dfecs(interp::Interp{N}) where N
+    basis = interp.basis
     all(d -> _foc_suitable(basis.params[d]), 1:N) || return nothing
     return ntuple(d -> DerivFunEvalCache(
                basis, ntuple(i -> Int(i == d), Val(N))), Val(N))
@@ -431,7 +428,7 @@ function evaluate!(res::CDPSolveResult, fec::FunEvalCache)
     elseif a isa ContinuousActions && _action_dim(a) > 1
         # Respect the inner solver used by `solve`: a :brent solve must not
         # have its policy re-evaluated through the derivative-based path
-        dfecs = res.inner_solver == :foc ? _eval_dfecs(cdp) : nothing
+        dfecs = res.inner_solver == :foc ? _eval_dfecs(res.interp) : nothing
         dfecs === nothing || foreach(dfec -> set_coefs!(dfec, C), dfecs)
         for i in 1:n
             res.V[i] = _s_wise_max_multi!(cdp, _row(s_nodes, i), C, fec,
@@ -439,7 +436,7 @@ function evaluate!(res::CDPSolveResult, fec::FunEvalCache)
                                           dfecs !== nothing)
         end
     else
-        s_wise_max!(cdp, s_nodes, C, res.V, res.X, fec)
+        s_wise_max!(_colloc(res), s_nodes, C, res.V, res.X, fec)
     end
     for i in 1:n
         res.resid[i] = res.V[i] - funeval_point!(fec, C, _row(s_nodes, i))
@@ -448,7 +445,7 @@ function evaluate!(res::CDPSolveResult, fec::FunEvalCache)
 end
 
 evaluate!(res::CDPSolveResult) =
-    evaluate!(res, FunEvalCache(res.cdp.interp.basis))
+    evaluate!(res, FunEvalCache(res.interp.basis))
 
 function set_eval_nodes!(
         res::CDPSolveResult{Algo,1}, s_nodes_coord::NTuple{1,Vector{Float64}}
@@ -506,7 +503,7 @@ policy, and `resid` is the Bellman residual at `s_nodes`.
 function (res::CDPSolveResult)(s_nodes::AbstractArray{Float64})
     cdp, C = res.cdp, res.C
     a = cdp.actions
-    fec = FunEvalCache(cdp.interp.basis)
+    fec = FunEvalCache(res.interp.basis)
     n = size(s_nodes, 1)
     if a isa DiscreteActions
         V = Vector{Float64}(undef, n)
@@ -518,7 +515,7 @@ function (res::CDPSolveResult)(s_nodes::AbstractArray{Float64})
     elseif a isa ContinuousActions && _action_dim(a) > 1
         V = Vector{Float64}(undef, n)
         X = _policy_buffer(a, n)
-        dfecs = res.inner_solver == :foc ? _eval_dfecs(cdp) : nothing
+        dfecs = res.inner_solver == :foc ? _eval_dfecs(res.interp) : nothing
         dfecs === nothing || foreach(dfec -> set_coefs!(dfec, C), dfecs)
         for i in 1:n
             V[i] = _s_wise_max_multi!(cdp, _row(s_nodes, i), C, fec,
@@ -526,7 +523,7 @@ function (res::CDPSolveResult)(s_nodes::AbstractArray{Float64})
                                       dfecs !== nothing)
         end
     else
-        V, X = s_wise_max(cdp, s_nodes, C, fec)
+        V, X = s_wise_max(_colloc(res), s_nodes, C, fec)
     end
     resid = Vector{Float64}(undef, n)
     for i in 1:n
@@ -582,16 +579,18 @@ _foc_suitable(p::SplineParams) = p.k >= 2
 _foc_suitable(p::BasisParams) = false
 
 """
-    CDPWorkspace(cdp::ContinuousDP; inner_solver=:foc)
+    CDPWorkspace(cp::_CollocationProblem; inner_solver=:foc)
 
-Construct a `CDPWorkspace` for `cdp`. See [`solve`](@ref) for the meaning of
-`inner_solver`.
+Construct a `CDPWorkspace` for the bound problem `cp`. See [`solve`](@ref)
+for the meaning of `inner_solver`.
 """
-function CDPWorkspace(cdp::ContinuousDP{N}; inner_solver::Symbol=:foc) where N
+function CDPWorkspace(cp::_CollocationProblem{N};
+                      inner_solver::Symbol=:foc) where N
     inner_solver in (:foc, :brent) ||
         throw(ArgumentError("inner_solver must be :foc or :brent"))
-    basis = cdp.interp.basis
-    n = cdp.interp.length
+    cdp, interp = cp.cdp, cp.interp
+    basis = interp.basis
+    n = interp.length
     discrete = cdp.actions isa DiscreteActions
     dfecs = if !discrete && inner_solver == :foc &&
                all(d -> _foc_suitable(basis.params[d]), 1:N)
@@ -698,10 +697,11 @@ end
 
 # Enumeration over all interpolation nodes, storing values in `Tv` and
 # action indices in `X_ind`
-function _s_wise_max_discrete_sweep!(cdp::ContinuousDP, C::Vector{Float64},
+function _s_wise_max_discrete_sweep!(cp::_CollocationProblem,
+                                     C::Vector{Float64},
                                      Tv::Vector{Float64}, X_ind::Vector{Int},
                                      fec::FunEvalCache)
-    ss = cdp.interp.S
+    cdp, ss = cp.cdp, cp.interp.S
     for i in 1:size(ss, 1)
         Tv[i], X_ind[i] = _s_wise_max_discrete!(cdp, _row(ss, i), C, fec)
     end
@@ -874,11 +874,11 @@ warm starts (`NaN` entries mean cold start). Sets the coefficients of
 `dfecs` from `C`. Falls back to Brent state-by-state on exceptions from the
 model functions (e.g. a `DomainError` at a finite-difference point).
 """
-function _s_wise_max_foc_sweep!(cdp::ContinuousDP, C::Vector{Float64},
+function _s_wise_max_foc_sweep!(cp::_CollocationProblem, C::Vector{Float64},
                                 Tv::Vector{Float64}, X::Vector{Float64},
                                 fec::FunEvalCache, dfecs)
     foreach(dfec -> set_coefs!(dfec, C), dfecs)
-    ss = cdp.interp.S
+    cdp, ss = cp.cdp, cp.interp.S
     for i in 1:size(ss, 1)
         s = _row(ss, i)
         Tv[i], X[i] =
@@ -1095,13 +1095,14 @@ end
 
 # Sweep over all interpolation nodes for M-dimensional continuous actions;
 # rows of `X` are warm starts on input and maximizers on output
-function _s_wise_max_multi_sweep!(cdp::ContinuousDP, C::Vector{Float64},
+function _s_wise_max_multi_sweep!(cp::_CollocationProblem,
+                                  C::Vector{Float64},
                                   Tv::Vector{Float64}, X::Matrix{Float64},
                                   fec::FunEvalCache, dfecs, use_foc::Bool)
     if use_foc && dfecs !== nothing
         foreach(dfec -> set_coefs!(dfec, C), dfecs)
     end
-    ss = cdp.interp.S
+    cdp, ss = cp.cdp, cp.interp.S
     for i in 1:size(ss, 1)
         Tv[i] = _s_wise_max_multi!(cdp, _row(ss, i), C, fec, dfecs,
                                    view(X, i, :), use_foc)
@@ -1129,9 +1130,10 @@ action spaces are handled internally by the operators.
 
 - `Tv::Vector{Float64}`: Updated value function vector.
 """
-function s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+function s_wise_max!(cp::_CollocationProblem, ss::AbstractArray{Float64},
                      C::Vector{Float64}, Tv::Vector{Float64},
                      fec::FunEvalCache)
+    cdp = cp.cdp
     n = size(ss, 1)
     for i in 1:n
         Tv[i], _ = _s_wise_max!(cdp, _row(ss, i), C, fec)
@@ -1139,9 +1141,9 @@ function s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
     return Tv
 end
 
-s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+s_wise_max!(cp::_CollocationProblem, ss::AbstractArray{Float64},
             C::Vector{Float64}, Tv::Vector{Float64}) =
-    s_wise_max!(cdp, ss, C, Tv, FunEvalCache(cdp.interp.basis))
+    s_wise_max!(cp, ss, C, Tv, FunEvalCache(cp.interp.basis))
 
 """
     s_wise_max!(cdp, ss, C, Tv, X[, fec])
@@ -1163,9 +1165,10 @@ Find optimal value and action for each grid point.
 - `Tv::Vector{Float64}`: Updated value function vector.
 - `X::Vector{Float64}`: Updated policy function vector.
 """
-function s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+function s_wise_max!(cp::_CollocationProblem, ss::AbstractArray{Float64},
                      C::Vector{Float64}, Tv::Vector{Float64},
                      X::Vector{Float64}, fec::FunEvalCache)
+    cdp = cp.cdp
     n = size(ss, 1)
     for i in 1:n
         Tv[i], X[i] = _s_wise_max!(cdp, _row(ss, i), C, fec)
@@ -1173,9 +1176,9 @@ function s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
     return Tv, X
 end
 
-s_wise_max!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+s_wise_max!(cp::_CollocationProblem, ss::AbstractArray{Float64},
             C::Vector{Float64}, Tv::Vector{Float64}, X::Vector{Float64}) =
-    s_wise_max!(cdp, ss, C, Tv, X, FunEvalCache(cdp.interp.basis))
+    s_wise_max!(cp, ss, C, Tv, X, FunEvalCache(cp.interp.basis))
 
 """
     s_wise_max(cdp, ss, C[, fec])
@@ -1195,16 +1198,16 @@ Find optimal value and action for each grid point.
 - `Tv::Vector{Float64}`: Value function vector.
 - `X::Vector{Float64}`: Policy function vector.
 """
-function s_wise_max(cdp::ContinuousDP, ss::AbstractArray{Float64},
+function s_wise_max(cp::_CollocationProblem, ss::AbstractArray{Float64},
                     C::Vector{Float64}, fec::FunEvalCache)
     n = size(ss, 1)
     Tv, X = Array{Float64}(undef, n), Array{Float64}(undef, n)
-    s_wise_max!(cdp, ss, C, Tv, X, fec)
+    s_wise_max!(cp, ss, C, Tv, X, fec)
 end
 
-s_wise_max(cdp::ContinuousDP, ss::AbstractArray{Float64},
+s_wise_max(cp::_CollocationProblem, ss::AbstractArray{Float64},
            C::Vector{Float64}) =
-    s_wise_max(cdp, ss, C, FunEvalCache(cdp.interp.basis))
+    s_wise_max(cp, ss, C, FunEvalCache(cp.interp.basis))
 
 
 """
@@ -1225,36 +1228,38 @@ stored in `Tv` (or `ws.Tv`).
 
 - `C::Vector{Float64}`: Updated basis coefficient vector.
 """
-function bellman_operator!(cdp::ContinuousDP, C::Vector{Float64},
+function bellman_operator!(cp::_CollocationProblem, C::Vector{Float64},
                            ws::CDPWorkspace)
+    cdp, interp = cp.cdp, cp.interp
     if cdp.actions isa DiscreteActions
-        _s_wise_max_discrete_sweep!(cdp, C, ws.Tv, ws.X_ind, ws.fec)
+        _s_wise_max_discrete_sweep!(cp, C, ws.Tv, ws.X_ind, ws.fec)
     elseif cdp.actions isa ContinuousActions && _action_dim(cdp.actions) > 1
-        _s_wise_max_multi_sweep!(cdp, C, ws.Tv, ws.X, ws.fec, ws.dfecs,
+        _s_wise_max_multi_sweep!(cp, C, ws.Tv, ws.X, ws.fec, ws.dfecs,
                                  ws.inner_solver == :foc)
     elseif _use_foc(ws)
-        _s_wise_max_foc_sweep!(cdp, C, ws.Tv, ws.X, ws.fec, ws.dfecs)
+        _s_wise_max_foc_sweep!(cp, C, ws.Tv, ws.X, ws.fec, ws.dfecs)
     else
-        s_wise_max!(cdp, cdp.interp.S, C, ws.Tv, ws.X, ws.fec)
+        s_wise_max!(cp, interp.S, C, ws.Tv, ws.X, ws.fec)
     end
-    ldiv!(C, cdp.interp.Phi_lu, ws.Tv)
+    ldiv!(C, interp.Phi_lu, ws.Tv)
     return C
 end
 
-function bellman_operator!(cdp::ContinuousDP, C::Vector{Float64},
+function bellman_operator!(cp::_CollocationProblem, C::Vector{Float64},
                            Tv::Vector{Float64})
+    cdp, interp = cp.cdp, cp.interp
     if cdp.actions isa DiscreteActions
         X_ind = Vector{Int}(undef, length(Tv))
-        _s_wise_max_discrete_sweep!(cdp, C, Tv, X_ind,
-                                    FunEvalCache(cdp.interp.basis))
+        _s_wise_max_discrete_sweep!(cp, C, Tv, X_ind,
+                                    FunEvalCache(interp.basis))
     elseif cdp.actions isa ContinuousActions && _action_dim(cdp.actions) > 1
-        ws = CDPWorkspace(cdp)
-        _s_wise_max_multi_sweep!(cdp, C, Tv, ws.X, ws.fec, ws.dfecs,
+        ws = CDPWorkspace(cp)
+        _s_wise_max_multi_sweep!(cp, C, Tv, ws.X, ws.fec, ws.dfecs,
                                  ws.inner_solver == :foc)
     else
-        s_wise_max!(cdp, cdp.interp.S, C, Tv)
+        s_wise_max!(cp, interp.S, C, Tv)
     end
-    ldiv!(C, cdp.interp.Phi_lu, Tv)
+    ldiv!(C, interp.Phi_lu, Tv)
     return C
 end
 
@@ -1278,9 +1283,10 @@ Compute the greedy policy for the given basis coefficients.
 
 - `X::Vector{Float64}`: Updated policy function vector.
 """
-function compute_greedy!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+function compute_greedy!(cp::_CollocationProblem, ss::AbstractArray{Float64},
                          C::Vector{Float64}, X::Vector{Float64},
                          fec::FunEvalCache)
+    cdp = cp.cdp
     n = size(ss, 1)
     for i in 1:n
         _, X[i] = _s_wise_max!(cdp, _row(ss, i), C, fec)
@@ -1288,12 +1294,13 @@ function compute_greedy!(cdp::ContinuousDP, ss::AbstractArray{Float64},
     return X
 end
 
-compute_greedy!(cdp::ContinuousDP, ss::AbstractArray{Float64},
+compute_greedy!(cp::_CollocationProblem, ss::AbstractArray{Float64},
                 C::Vector{Float64}, X::Vector{Float64}) =
-    compute_greedy!(cdp, ss, C, X, FunEvalCache(cdp.interp.basis))
+    compute_greedy!(cp, ss, C, X, FunEvalCache(cp.interp.basis))
 
-compute_greedy!(cdp::ContinuousDP, C::Vector{Float64}, X::Vector{Float64}) =
-    compute_greedy!(cdp, cdp.interp.S, C, X)
+compute_greedy!(cp::_CollocationProblem, C::Vector{Float64},
+                X::Vector{Float64}) =
+    compute_greedy!(cp, cp.interp.S, C, X)
 
 """
     evaluate_policy!(cdp, X, C[, fec])
@@ -1318,10 +1325,11 @@ factorized in sparse form.
 
 - `C::Vector{Float64}`: Updated basis coefficient vector.
 """
-function evaluate_policy!(cdp::ContinuousDP, X::AbstractVecOrMat,
+function evaluate_policy!(cp::_CollocationProblem, X::AbstractVecOrMat,
                           C::Vector{Float64}, fec::FunEvalCache)
-    A_lu = _policy_system_lu(cdp.interp.Phi, cdp, X, fec)
-    ss = cdp.interp.S
+    cdp, interp = cp.cdp, cp.interp
+    A_lu = _policy_system_lu(interp.Phi, cp, X, fec)
+    ss = interp.S
     for i in 1:size(ss, 1)
         C[i] = cdp.f(_row(ss, i), _row(X, i))
     end
@@ -1329,9 +1337,9 @@ function evaluate_policy!(cdp::ContinuousDP, X::AbstractVecOrMat,
     return C
 end
 
-evaluate_policy!(cdp::ContinuousDP, X::AbstractVecOrMat,
+evaluate_policy!(cp::_CollocationProblem, X::AbstractVecOrMat,
                  C::Vector{Float64}) =
-    evaluate_policy!(cdp, X, C, FunEvalCache(cdp.interp.basis))
+    evaluate_policy!(cp, X, C, FunEvalCache(cp.interp.basis))
 
 # Evaluate the per-dimension basis functions at the point `x` (values are
 # left in `fec.caches[d].vals`) and return `(nvals, base)`: the number of
@@ -1353,10 +1361,11 @@ end
 
 # Dense path: A = Phi - beta * E[Phi(g(S, X, e))] assembled in place,
 # factorized with an in-place dense LU
-function _policy_system_lu(Phi::AbstractMatrix, cdp::ContinuousDP, X, fec)
-    n = size(cdp.interp.S, 1)
+function _policy_system_lu(Phi::AbstractMatrix, cp::_CollocationProblem,
+                           X, fec)
+    cdp, ss = cp.cdp, cp.interp.S
+    n = size(ss, 1)
     A = copyto!(Matrix{Float64}(undef, n, n), Phi)
-    ss = cdp.interp.S
     for i in 1:n
         s = _row(ss, i)
         for j in eachindex(cdp.weights)
@@ -1395,10 +1404,11 @@ end
 # Sparse path: assemble E = E[Phi(g(S, X, e))] in triplet form (exploiting
 # that only few basis functions are nonzero at each point), then factorize
 # A = Phi - beta * E with a sparse LU
-function _policy_system_lu(Phi::SparseMatrixCSC, cdp::ContinuousDP, X, fec)
-    n = size(cdp.interp.S, 1)
+function _policy_system_lu(Phi::SparseMatrixCSC, cp::_CollocationProblem,
+                           X, fec)
+    cdp, ss = cp.cdp, cp.interp.S
+    n = size(ss, 1)
     Is, Js, Vs = Int[], Int[], Float64[]
-    ss = cdp.interp.S
     for i in 1:n
         s = _row(ss, i)
         for j in eachindex(cdp.weights)
@@ -1454,29 +1464,30 @@ Perform one step of policy function iteration and update the basis coefficients.
 
 - `C::Vector{Float64}`: Updated basis coefficient vector.
 """
-function policy_iteration_operator!(cdp::ContinuousDP, C::Vector{Float64},
-                                    ws::CDPWorkspace)
+function policy_iteration_operator!(cp::_CollocationProblem,
+                                    C::Vector{Float64}, ws::CDPWorkspace)
+    cdp = cp.cdp
     if cdp.actions isa DiscreteActions
-        _s_wise_max_discrete_sweep!(cdp, C, ws.Tv, ws.X_ind, ws.fec)
-        evaluate_policy!(cdp, view(cdp.actions.vals, ws.X_ind), C, ws.fec)
+        _s_wise_max_discrete_sweep!(cp, C, ws.Tv, ws.X_ind, ws.fec)
+        evaluate_policy!(cp, view(cdp.actions.vals, ws.X_ind), C, ws.fec)
     elseif cdp.actions isa ContinuousActions && _action_dim(cdp.actions) > 1
-        _s_wise_max_multi_sweep!(cdp, C, ws.Tv, ws.X, ws.fec, ws.dfecs,
+        _s_wise_max_multi_sweep!(cp, C, ws.Tv, ws.X, ws.fec, ws.dfecs,
                                  ws.inner_solver == :foc)
-        evaluate_policy!(cdp, ws.X, C, ws.fec)
+        evaluate_policy!(cp, ws.X, C, ws.fec)
     elseif _use_foc(ws)
-        _s_wise_max_foc_sweep!(cdp, C, ws.Tv, ws.X, ws.fec, ws.dfecs)
-        evaluate_policy!(cdp, ws.X, C, ws.fec)
+        _s_wise_max_foc_sweep!(cp, C, ws.Tv, ws.X, ws.fec, ws.dfecs)
+        evaluate_policy!(cp, ws.X, C, ws.fec)
     else
-        compute_greedy!(cdp, cdp.interp.S, C, ws.X, ws.fec)
-        evaluate_policy!(cdp, ws.X, C, ws.fec)
+        compute_greedy!(cp, cp.interp.S, C, ws.X, ws.fec)
+        evaluate_policy!(cp, ws.X, C, ws.fec)
     end
     return C
 end
 
-function policy_iteration_operator!(cdp::ContinuousDP, C::Vector{Float64},
-                                    X::Vector{Float64})
-    compute_greedy!(cdp, C, X)
-    evaluate_policy!(cdp, X, C)
+function policy_iteration_operator!(cp::_CollocationProblem,
+                                    C::Vector{Float64}, X::Vector{Float64})
+    compute_greedy!(cp, C, X)
+    evaluate_policy!(cp, X, C)
     return C
 end
 
@@ -1686,7 +1697,7 @@ function solve(cdp::ContinuousDP, solver::CollocationSolver{Algo};
                v_init=nothing, verbose::Integer=2,
                print_skip::Integer=50) where {Algo<:DPAlgorithm}
     interp = Interp(solver.basis)
-    return _solve_core(_with_interp(cdp, interp), Algo,
+    return _solve_core(_CollocationProblem(cdp, interp), Algo,
                        _check_v_init(v_init, interp),
                        solver.tol, solver.max_iter, solver.inner_solver,
                        verbose, print_skip)
@@ -1695,7 +1706,7 @@ end
 function solve(cdp::ContinuousDP, solver::LQASolver;
                v_init=nothing, verbose::Integer=2, print_skip::Integer=50)
     interp = Interp(solver.basis)
-    return _solve_core(_with_interp(cdp, interp), LQA,
+    return _solve_core(_CollocationProblem(cdp, interp), LQA,
                        _check_v_init(v_init, interp),
                        sqrt(eps()), 500, :brent,
                        verbose, print_skip; point=solver.point)
@@ -1710,16 +1721,17 @@ function _check_v_init(v_init::AbstractVector, interp::Interp)
 end
 
 # Shared solve pipeline over a problem with a bound interpolation scheme
-function _solve_core(cdp::ContinuousDP{N}, ::Type{Algo},
+function _solve_core(cp::_CollocationProblem, ::Type{Algo},
                      v_init::Vector{Float64}, tol::Float64, max_iter::Int,
                      inner_solver::Symbol, verbose::Integer,
                      print_skip::Integer;
-                     kwargs...) where {Algo<:DPAlgorithm,N}
-    res = CDPSolveResult{Algo,N}(cdp, tol, max_iter, inner_solver)
+                     kwargs...) where {Algo<:DPAlgorithm}
+    res = CDPSolveResult{Algo}(cp.cdp, cp.interp, tol, max_iter,
+                               inner_solver)
     # LQA has no inner maximization: skip the FOC derivative caches
-    ws = CDPWorkspace(cdp; inner_solver=(Algo === LQA ? :brent : inner_solver))
-    ldiv!(res.C, cdp.interp.Phi_lu, v_init)
-    _solve!(cdp, res, ws, verbose, print_skip; kwargs...)
+    ws = CDPWorkspace(cp; inner_solver=(Algo === LQA ? :brent : inner_solver))
+    ldiv!(res.C, cp.interp.Phi_lu, v_init)
+    _solve!(cp, res, ws, verbose, print_skip; kwargs...)
     evaluate!(res, ws.fec)
     return res
 end
@@ -1742,13 +1754,13 @@ Policy function iteration algorithm for `solve`.
 PFI
 
 """
-    _solve!(cdp, res, ws, verbose, print_skip)
+    _solve!(cp, res, ws, verbose, print_skip)
 
 Implement policy iteration. See `solve` for further details.
 """
-function _solve!(cdp::ContinuousDP, res::CDPSolveResult{PFI},
+function _solve!(cp::_CollocationProblem, res::CDPSolveResult{PFI},
                  ws::CDPWorkspace, verbose, print_skip)
-    operator!(C) = policy_iteration_operator!(cdp, C, ws)
+    operator!(C) = policy_iteration_operator!(cp, C, ws)
     res.converged, res.num_iter =
         operator_iteration!(operator!, res.C, res.tol, res.max_iter,
                             verbose=verbose, print_skip=print_skip)
@@ -1765,13 +1777,13 @@ Value function iteration algorithm for `solve`.
 VFI
 
 """
-    _solve!(cdp, res, ws, verbose, print_skip)
+    _solve!(cp, res, ws, verbose, print_skip)
 
 Implement value iteration. See `solve` for further details.
 """
-function _solve!(cdp::ContinuousDP, res::CDPSolveResult{VFI},
+function _solve!(cp::_CollocationProblem, res::CDPSolveResult{VFI},
                  ws::CDPWorkspace, verbose, print_skip)
-    operator!(C) = bellman_operator!(cdp, C, ws)
+    operator!(C) = bellman_operator!(cp, C, ws)
     res.converged, res.num_iter =
         operator_iteration!(operator!, res.C, res.tol, res.max_iter,
                             verbose=verbose, print_skip=print_skip)
@@ -1784,20 +1796,21 @@ end
 
 Linear-quadratic approximation algorithm for `solve`.
 
-Use as `solve(cdp, LQA; point=(s, x, e))` to approximate the model around a
-reference point and solve the resulting LQ problem.
+Used via `solve(cdp, LQASolver(basis; point=(s, x, e)))` to approximate the
+model around a reference point and solve the resulting LQ problem.
 """
 struct LQA <: DPAlgorithm end
 
 """
-    _solve!(cdp, res, ws, verbose, print_skip; point)
+    _solve!(cp, res, ws, verbose, print_skip; point)
 
 Implement linear quadratic approximation. See `solve` for further details.
 """
-function _solve!(cdp::ContinuousDP,
+function _solve!(cp::_CollocationProblem,
                  res::CDPSolveResult{LQA},
                  ws::CDPWorkspace, verbose, print_skip;
                  point::Tuple{ScalarOrArray, ScalarOrArray, ScalarOrArray})
+    cdp, interp = cp.cdp, cp.interp
     cdp.actions isa ContinuousActions || throw(ArgumentError(
         "LQA requires a continuous action space"))
 
@@ -1838,10 +1851,10 @@ function _solve!(cdp::ContinuousDP,
 
     # Compute value function
     v(s) = -([1, s...]' * P * [1, s...] + d)
-    v_vals = [v(cdp.interp.S[i, :]) for i in 1:length(cdp.interp.basis)]
+    v_vals = [v(interp.S[i, :]) for i in 1:length(interp.basis)]
 
     # Back out basis coefficients
-    ldiv!(res.C, cdp.interp.Phi_lu, v_vals)
+    ldiv!(res.C, interp.Phi_lu, v_vals)
 
     res.converged = true
 end
@@ -1863,7 +1876,7 @@ struct ValueFunction{TF<:FunEvalCache}
 end
 
 ValueFunction(res::CDPSolveResult) =
-    ValueFunction(res.C, FunEvalCache(res.cdp.interp.basis))
+    ValueFunction(res.C, FunEvalCache(res.interp.basis))
 
 (vf::ValueFunction)(s) = funeval_point!(vf.fec, vf.C, s)
 
@@ -1927,7 +1940,7 @@ function PolicyFunction(res::CDPSolveResult{Algo,N}) where {Algo,N}
     a = res.cdp.actions
     if a isa DiscreteActions
         return _GreedyPolicyFunction(res.cdp, res.C,
-                                     FunEvalCache(res.cdp.interp.basis),
+                                     FunEvalCache(res.interp.basis),
                                      a.vals)
     end
     basis = Basis(map(LinParams, res.eval_nodes_coord, ntuple(i -> 0, N)))

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -250,8 +250,8 @@ function ContinuousDP(; f, g, discount, shocks, weights,
     return ContinuousDP(f, g, discount, shocks, weights, actions)
 end
 
-# TODO(v0.5): delete these error stubs (kept for one release after the
-# removal of the basis-endowed constructors in v0.4). The 7-arg stub is
+# TODO: delete these error stubs in a later release (kept for migration
+# guidance from the v0.2 API, removed in v0.3). The 7-arg stub is
 # load-bearing beyond ergonomics: without it, the removed
 # `(..., actions, basis)` form would silently match the primitives
 # `(..., x_lb, x_ub)` method and construct a nonsense action space.
@@ -259,15 +259,15 @@ ContinuousDP(f, g, discount::Real,
              shocks::AbstractVecOrMat, weights::Vector{Float64},
              actions_or_x_lb, basis::Basis) =
     throw(ArgumentError(
-        "the basis-endowed `ContinuousDP` constructors were removed in " *
-        "v0.4: construct the problem without `basis` and pass " *
+        "the basis-endowed `ContinuousDP` constructors have been removed: " *
+        "construct the problem without `basis` and pass " *
         "`CollocationSolver(basis)` to `solve`"))
 ContinuousDP(f, g, discount::Real,
              shocks::AbstractVecOrMat, weights::Vector{Float64},
              x_lb, x_ub, basis::Basis) =
     throw(ArgumentError(
-        "the basis-endowed `ContinuousDP` constructors were removed in " *
-        "v0.4: construct the problem without `basis` and pass " *
+        "the basis-endowed `ContinuousDP` constructors have been removed: " *
+        "construct the problem without `basis` and pass " *
         "`CollocationSolver(basis)` to `solve`"))
 
 """
@@ -1736,11 +1736,11 @@ function _solve_core(cp::_CollocationProblem, ::Type{Algo},
     return res
 end
 
-# TODO(v0.5): delete this error stub (kept for one release after the
-# removal of the deprecated `solve(cdp, method; ...)` in v0.4)
+# TODO: delete this error stub in a later release (kept for migration
+# guidance from the v0.2 API, removed in v0.3)
 solve(cdp::ContinuousDP, ::Type{<:DPAlgorithm}=PFI; kwargs...) =
     throw(ArgumentError(
-        "`solve(cdp, PFI/VFI/LQA; ...)` was removed in v0.4: pass a " *
+        "`solve(cdp, PFI/VFI/LQA; ...)` has been removed: pass a " *
         "solver object, e.g. `solve(cdp, CollocationSolver(basis))` or " *
         "`solve(cdp, LQASolver(basis; point=point))`"))
 

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -257,31 +257,25 @@ function ContinuousDP(; f, g, discount, shocks, weights,
     return ContinuousDP(f, g, discount, shocks, weights, actions)
 end
 
-# Deprecated basis-endowed forms: the basis now belongs to the solver
-function ContinuousDP(f, g, discount::Real,
-                      shocks::AbstractVecOrMat, weights::Vector{Float64},
-                      actions::ActionSpace,
-                      basis::Basis{N}) where {N}
-    Base.depwarn(
-        "`ContinuousDP(f, g, discount, shocks, weights, actions, basis)` " *
-        "is deprecated: construct the problem without `basis` and pass " *
-        "`CollocationSolver(basis)` to `solve`.", :ContinuousDP)
-    return _with_interp(
-        ContinuousDP(f, g, discount, shocks, weights, actions), Interp(basis))
-end
-
-function ContinuousDP(f, g, discount::Real,
-                      shocks::AbstractVecOrMat, weights::Vector{Float64},
-                      x_lb, x_ub, basis::Basis)
-    Base.depwarn(
-        "`ContinuousDP(f, g, discount, shocks, weights, x_lb, x_ub, basis)` " *
-        "is deprecated: construct the problem without `basis` and pass " *
-        "`CollocationSolver(basis)` to `solve`.", :ContinuousDP)
-    return _with_interp(
-        ContinuousDP(f, g, discount, shocks, weights,
-                     ContinuousActions(x_lb, x_ub)),
-        Interp(basis))
-end
+# TODO(v0.5): delete these error stubs (kept for one release after the
+# removal of the basis-endowed constructors in v0.4). The 7-arg stub is
+# load-bearing beyond ergonomics: without it, the removed
+# `(..., actions, basis)` form would silently match the primitives
+# `(..., x_lb, x_ub)` method and construct a nonsense action space.
+ContinuousDP(f, g, discount::Real,
+             shocks::AbstractVecOrMat, weights::Vector{Float64},
+             actions_or_x_lb, basis::Basis) =
+    throw(ArgumentError(
+        "the basis-endowed `ContinuousDP` constructors were removed in " *
+        "v0.4: construct the problem without `basis` and pass " *
+        "`CollocationSolver(basis)` to `solve`"))
+ContinuousDP(f, g, discount::Real,
+             shocks::AbstractVecOrMat, weights::Vector{Float64},
+             x_lb, x_ub, basis::Basis) =
+    throw(ArgumentError(
+        "the basis-endowed `ContinuousDP` constructors were removed in " *
+        "v0.4: construct the problem without `basis` and pass " *
+        "`CollocationSolver(basis)` to `solve`"))
 
 """
     ContinuousDP(cdp::ContinuousDP; f=cdp.f, g=cdp.g, discount=cdp.discount,
@@ -291,9 +285,6 @@ end
 Construct a copy of `cdp`, optionally replacing selected model components.
 The `x_lb`/`x_ub` keywords replace the corresponding bound of a continuous
 action space.
-
-The keyword `basis` is also accepted but deprecated (removal planned for
-v0.4): pass `CollocationSolver(basis)` to `solve` instead.
 """
 function ContinuousDP(cdp::ContinuousDP;
     f = cdp.f,
@@ -303,8 +294,7 @@ function ContinuousDP(cdp::ContinuousDP;
     weights = cdp.weights,
     actions = cdp.actions,
     x_lb = nothing,
-    x_ub = nothing,
-    basis = nothing
+    x_ub = nothing
 )
     if x_lb !== nothing || x_ub !== nothing
         actions isa ContinuousActions || throw(ArgumentError(
@@ -315,15 +305,6 @@ function ContinuousDP(cdp::ContinuousDP;
         )
     end
     out = ContinuousDP(f, g, discount, shocks, weights, actions)
-    if basis !== nothing
-        Base.depwarn(
-            "the `basis` keyword of the ContinuousDP copy constructor is " *
-            "deprecated: pass `CollocationSolver(basis)` to `solve` instead.",
-            :ContinuousDP)
-        return _with_interp(out, Interp(basis))
-    end
-    # Preserve an interp bound by the deprecated basis-endowed constructor
-    cdp.interp === nothing || return _with_interp(out, cdp.interp)
     return out
 end
 
@@ -1743,69 +1724,13 @@ function _solve_core(cdp::ContinuousDP{N}, ::Type{Algo},
     return res
 end
 
-"""
-    solve(cdp, method=PFI; v_init=zeros(cdp.interp.length), tol=sqrt(eps()),
-          max_iter=500, verbose=2, print_skip=50, kwargs...)
-
-Deprecated `solve` method for problems constructed with the deprecated
-basis-endowed `ContinuousDP` constructor. Use
-`solve(cdp, CollocationSolver(basis; ...))` (or `LQASolver`) instead.
-
-# Arguments
-
-- `cdp::ContinuousDP`: The dynamic program to solve.
-- `method::Type{<:DPAlgorithm}`: Solution method. `VFI` for value
-  function iteration, `PFI` for policy function iteration, or `LQA` for linear
-  quadratic approximation. Default is `PFI`.
-- `v_init::Vector{Float64}`: Initial value function values at interpolation
-   nodes.
-- `tol::Real`: Convergence tolerance.
-- `max_iter::Integer`: Maximum number of iterations.
-- `verbose::Integer`: Level of feedback (0 for no output, 1 for warnings only,
-  2 for warning and convergence messages during iteration).
-- `print_skip::Integer`: If `verbose == 2`, how many iterations between print
-  messages.
-- `inner_solver::Symbol`: How to solve the inner maximization over actions
-  in VFI and PFI (`:foc` or `:brent`; see [`CollocationSolver`](@ref)).
-- `point::Tuple{ScalarOrArray, ScalarOrArray, ScalarOrArray}`: Keyword argument
-  required when `method` is `LQA`. Specify the steady state `(s, x, e)` around
-  which the LQ approximation is constructed.
-
-# Returns
-
-- `res::CDPSolveResult`: Solution object of the dynamic program.
-"""
-function solve(cdp::ContinuousDP{N}, method::Type{Algo}=PFI;
-               v_init=nothing,
-               tol::Real=sqrt(eps()), max_iter::Integer=500,
-               verbose::Integer=2,
-               print_skip::Integer=50,
-               inner_solver::Symbol=:foc,
-               kwargs...) where {Algo<:DPAlgorithm,N}
-    cdp.interp === nothing && throw(ArgumentError(
-        "this ContinuousDP holds no interpolation basis; pass a solver, " *
-        "e.g. `solve(cdp, CollocationSolver(basis))`"))
-    if Algo === LQA
-        Base.depwarn(
-            "`solve(cdp, LQA; ...)` with the basis stored in the problem " *
-            "is deprecated: construct the problem without `basis` and " *
-            "call `solve(cdp, LQASolver(basis; point=point))`.", :solve)
-    else
-        Base.depwarn(
-            "`solve(cdp, method; ...)` with the basis stored in the " *
-            "problem is deprecated: construct the problem without `basis` " *
-            "and call " *
-            "`solve(cdp, CollocationSolver(basis; algorithm=$Algo, ...))`.",
-            :solve)
-    end
-    # Validate before the LQA override in _solve_core, so that an invalid
-    # value is rejected for every method, as documented
-    inner_solver in (:foc, :brent) ||
-        throw(ArgumentError("inner_solver must be :foc or :brent"))
-    return _solve_core(cdp, Algo, _check_v_init(v_init, cdp.interp),
-                       Float64(tol), Int(max_iter), inner_solver,
-                       verbose, print_skip; kwargs...)
-end
+# TODO(v0.5): delete this error stub (kept for one release after the
+# removal of the deprecated `solve(cdp, method; ...)` in v0.4)
+solve(cdp::ContinuousDP, ::Type{<:DPAlgorithm}=PFI; kwargs...) =
+    throw(ArgumentError(
+        "`solve(cdp, PFI/VFI/LQA; ...)` was removed in v0.4: pass a " *
+        "solver object, e.g. `solve(cdp, CollocationSolver(basis))` or " *
+        "`solve(cdp, LQASolver(basis; point=point))`"))
 
 
 # Policy iteration

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -536,8 +536,9 @@ end
 """
     CDPWorkspace{TF,TD}
 
-Preallocated buffers used by the solution algorithms for a `ContinuousDP`.
-Construct with `CDPWorkspace(cdp; inner_solver=:foc)`.
+Preallocated buffers used by the solution algorithms for a dynamic program
+bound to an interpolation scheme. Construct with
+`CDPWorkspace(cp; inner_solver=:foc)`.
 
 Not thread-safe: use one workspace per thread.
 
@@ -866,7 +867,7 @@ function _s_wise_max_foc!(cdp::ContinuousDP, s, C, fec::FunEvalCache, dfecs,
 end
 
 """
-    _s_wise_max_foc_sweep!(cdp, C, Tv, X, fec, dfecs)
+    _s_wise_max_foc_sweep!(cp, C, Tv, X, fec, dfecs)
 
 Run the FOC-based inner maximization over all interpolation nodes, storing
 values in `Tv` and maximizers in `X`. The previous contents of `X` serve as
@@ -1111,7 +1112,7 @@ function _s_wise_max_multi_sweep!(cp::_CollocationProblem,
 end
 
 """
-    s_wise_max!(cdp, ss, C, Tv[, fec])
+    s_wise_max!(cp, ss, C, Tv[, fec])
 
 Find optimal value for each grid point. These helpers apply to
 one-dimensional continuous action spaces; discrete and multi-dimensional
@@ -1119,7 +1120,8 @@ action spaces are handled internally by the operators.
 
 # Arguments
 
-- `cdp::ContinuousDP`: The dynamic program.
+- `cp::_CollocationProblem`: The dynamic program bound to its interpolation
+  scheme.
 - `ss::AbstractArray{Float64}`: Interpolation nodes.
 - `C::Vector{Float64}`: Basis coefficient vector for the value function.
 - `Tv::Vector{Float64}`: A buffer array to hold the updated value function.
@@ -1146,13 +1148,14 @@ s_wise_max!(cp::_CollocationProblem, ss::AbstractArray{Float64},
     s_wise_max!(cp, ss, C, Tv, FunEvalCache(cp.interp.basis))
 
 """
-    s_wise_max!(cdp, ss, C, Tv, X[, fec])
+    s_wise_max!(cp, ss, C, Tv, X[, fec])
 
 Find optimal value and action for each grid point.
 
 # Arguments
 
-- `cdp::ContinuousDP`: The dynamic program.
+- `cp::_CollocationProblem`: The dynamic program bound to its interpolation
+  scheme.
 - `ss::AbstractArray{Float64}`: Interpolation nodes.
 - `C::Vector{Float64}`: Basis coefficient vector for the value function.
 - `Tv::Vector{Float64}`: A buffer array to hold the updated value function.
@@ -1181,13 +1184,14 @@ s_wise_max!(cp::_CollocationProblem, ss::AbstractArray{Float64},
     s_wise_max!(cp, ss, C, Tv, X, FunEvalCache(cp.interp.basis))
 
 """
-    s_wise_max(cdp, ss, C[, fec])
+    s_wise_max(cp, ss, C[, fec])
 
 Find optimal value and action for each grid point.
 
 # Arguments
 
-- `cdp::ContinuousDP`: The dynamic program.
+- `cp::_CollocationProblem`: The dynamic program bound to its interpolation
+  scheme.
 - `ss::AbstractArray{Float64}`: Interpolation nodes.
 - `C::Vector{Float64}`: Basis coefficient vector for the value function.
 - `fec::FunEvalCache`: Workspace for point evaluation of the value function.
@@ -1211,15 +1215,16 @@ s_wise_max(cp::_CollocationProblem, ss::AbstractArray{Float64},
 
 
 """
-    bellman_operator!(cdp, C, Tv)
-    bellman_operator!(cdp, C, ws)
+    bellman_operator!(cp, C, Tv)
+    bellman_operator!(cp, C, ws)
 
 Apply the Bellman operator and update the basis coefficients. Values are
 stored in `Tv` (or `ws.Tv`).
 
 # Arguments
 
-- `cdp::ContinuousDP`: The dynamic program.
+- `cp::_CollocationProblem`: The dynamic program bound to its interpolation
+  scheme.
 - `C::Vector{Float64}`: Basis coefficient vector for the value function.
 - `Tv::Vector{Float64}`: Vector to store values.
 - `ws::CDPWorkspace`: Workspace for the solution algorithms.
@@ -1265,14 +1270,15 @@ end
 
 
 """
-    compute_greedy!(cdp, C, X)
-    compute_greedy!(cdp, ss, C, X[, fec])
+    compute_greedy!(cp, C, X)
+    compute_greedy!(cp, ss, C, X[, fec])
 
 Compute the greedy policy for the given basis coefficients.
 
 # Arguments
 
-- `cdp::ContinuousDP`: The dynamic program.
+- `cp::_CollocationProblem`: The dynamic program bound to its interpolation
+  scheme.
 - `ss::AbstractArray{Float64}`: Interpolation nodes.
 - `C::Vector{Float64}`: Basis coefficient vector for the value function.
 - `X::Vector{Float64}`: A buffer array to hold the updated policy function.
@@ -1303,7 +1309,7 @@ compute_greedy!(cp::_CollocationProblem, C::Vector{Float64},
     compute_greedy!(cp, cp.interp.S, C, X)
 
 """
-    evaluate_policy!(cdp, X, C[, fec])
+    evaluate_policy!(cp, X, C[, fec])
 
 Compute the value function for a given policy and update the basis
 coefficients: solve `(Phi - beta * E[Phi(g(S, X, e))]) C = f(S, X)`, where
@@ -1314,7 +1320,8 @@ factorized in sparse form.
 
 # Arguments
 
-- `cdp::ContinuousDP`: The dynamic program.
+- `cp::_CollocationProblem`: The dynamic program bound to its interpolation
+  scheme.
 - `X::AbstractVecOrMat`: Policy function (action values); an `n x M`
   matrix for `M`-dimensional continuous actions.
 - `C::Vector{Float64}`: A buffer array to hold the basis coefficients.
@@ -1448,14 +1455,15 @@ end
 
 
 """
-    policy_iteration_operator!(cdp, C, X)
-    policy_iteration_operator!(cdp, C, ws)
+    policy_iteration_operator!(cp, C, X)
+    policy_iteration_operator!(cp, C, ws)
 
 Perform one step of policy function iteration and update the basis coefficients.
 
 # Arguments
 
-- `cdp::ContinuousDP`: The dynamic program.
+- `cp::_CollocationProblem`: The dynamic program bound to its interpolation
+  scheme.
 - `C::Vector{Float64}`: Basis coefficient vector for the value function.
 - `X::Vector{Float64}`: A buffer array to hold the updated policy function.
 - `ws::CDPWorkspace`: Workspace for the solution algorithms.

--- a/test/test_cdp.jl
+++ b/test/test_cdp.jl
@@ -86,9 +86,9 @@
         end
 
         @testset "Test type inference" begin
-            interp_fact(res) = res.cdp.interp.Phi_lu
+            interp_fact(res) = res.interp.Phi_lu
             transition_fun(res) = res.cdp.g
-            interp_basis(res) = res.cdp.interp.basis
+            interp_basis(res) = res.interp.basis
 
             res = @inferred solve(cdp, CollocationSolver(bases[1]))
 

--- a/test/test_cdp_multidim.jl
+++ b/test/test_cdp_multidim.jl
@@ -159,7 +159,7 @@
                                            max_iter=500, tol=sqrt(eps()))
                 res = @inferred solve(cdp, solver, verbose=0)
                 @test ndims(res) == 2
-                @test ndims(res.cdp) == 2
+                @test ndims(res) == 2
 
                 results[test_name] = res
                 x_hat = vec(res.X)

--- a/test/test_cdp_multidim.jl
+++ b/test/test_cdp_multidim.jl
@@ -159,7 +159,7 @@
                                            max_iter=500, tol=sqrt(eps()))
                 res = @inferred solve(cdp, solver, verbose=0)
                 @test ndims(res) == 2
-                @test ndims(res) == 2
+                @test ndims(ContinuousDPs._colloc(res)) == 2
 
                 results[test_name] = res
                 x_hat = vec(res.X)

--- a/test/test_discrete_actions.jl
+++ b/test/test_discrete_actions.jl
@@ -20,7 +20,7 @@ using ContinuousDPs: CDPWorkspace, FunEvalCache, _s_wise_max_discrete!
     cdp_c = ContinuousDP(f_growth, g_growth, beta, shocks, weights,
                          s -> 1e-3, s -> s^alpha - s_min)
     # Bound instance for tests of internal functions
-    colloc_cdp_d = ContinuousDPs._with_interp(cdp_d, ContinuousDPs.Interp(basis))
+    colloc_cdp_d = ContinuousDPs._CollocationProblem(cdp_d, ContinuousDPs.Interp(basis))
 
     @testset "solve and compare with the continuous solution: $method" for
             method in (PFI, VFI)

--- a/test/test_evaluate_policy.jl
+++ b/test/test_evaluate_policy.jl
@@ -1,29 +1,30 @@
 using BasisMatrices: ckron, evalbase
-using ContinuousDPs: evaluate_policy!, FunEvalCache, Interp, _with_interp
+using ContinuousDPs: evaluate_policy!, FunEvalCache, Interp, _CollocationProblem
 using QuantEcon: qnwnorm
 
 @testset "evaluate_policy!" begin
     # Reference: the pre-optimization implementation (dense, per-point
     # evalbase + ckron row updates)
-    function evaluate_policy_ref(cdp, X)
-        N = ndims(cdp)
-        n = size(cdp.interp.S, 1)
-        ts = Base.tail(axes(cdp.interp.S))
+    function evaluate_policy_ref(colloc_cdp, X)
+        cdp, interp = colloc_cdp.cdp, colloc_cdp.interp
+        N = ndims(colloc_cdp)
+        n = size(interp.S, 1)
+        ts = Base.tail(axes(interp.S))
         te = Base.tail(axes(cdp.shocks))
         A = Array{Float64}(undef, n, n)
-        A[:] = cdp.interp.Phi
+        A[:] = interp.Phi
         for i in 1:n
-            s = cdp.interp.S[(i, ts...)...]
+            s = interp.S[(i, ts...)...]
             for (j, w) in enumerate(cdp.weights)
                 e = cdp.shocks[(j, te...)...]
                 s_next = cdp.g(s, X[i], e)
                 A[i, :] -= ckron(
-                    [vec(evalbase(cdp.interp.basis.params[k], s_next[k]))
+                    [vec(evalbase(interp.basis.params[k], s_next[k]))
                      for k in N:-1:1]...
                 ) * cdp.discount * w
             end
         end
-        C = [cdp.f(cdp.interp.S[(i, ts...)...], X[i]) for i in 1:n]
+        C = [cdp.f(interp.S[(i, ts...)...], X[i]) for i in 1:n]
         return A \ C
     end
 
@@ -38,16 +39,17 @@ using QuantEcon: qnwnorm
         g(s, x, e) = clamp(0.5 * s + 0.2 * x + 0.1 * e, 0., 1.)
         # evaluate_policy! is internal and operates on a problem with a
         # bound interpolation scheme
-        cdp = _with_interp(
+        colloc_cdp = _CollocationProblem(
             ContinuousDP(f, g, 0.9, shocks, weights, s -> 0., s -> 1.),
             Interp(basis))
-        X = [0.25 + 0.5 * s for s in cdp.interp.S]
-        C = Vector{Float64}(undef, cdp.interp.length)
-        evaluate_policy!(cdp, X, C)
-        @test C ≈ evaluate_policy_ref(cdp, X) rtol=1e-9
+        X = [0.25 + 0.5 * s for s in colloc_cdp.interp.S]
+        C = Vector{Float64}(undef, colloc_cdp.interp.length)
+        evaluate_policy!(colloc_cdp, X, C)
+        @test C ≈ evaluate_policy_ref(colloc_cdp, X) rtol=1e-9
         # fec-passing method gives the same result
-        C2 = Vector{Float64}(undef, cdp.interp.length)
-        evaluate_policy!(cdp, X, C2, FunEvalCache(cdp.interp.basis))
+        C2 = Vector{Float64}(undef, colloc_cdp.interp.length)
+        evaluate_policy!(colloc_cdp, X, C2,
+                         FunEvalCache(colloc_cdp.interp.basis))
         @test C2 == C
     end
 
@@ -64,14 +66,15 @@ using QuantEcon: qnwnorm
         f(s, x) = log(1 + s[1] + s[2] + x)
         g(s, x, e) = (clamp(0.5 * s[1] + 0.2 * x + 0.1 * e, 0., 1.),
                       clamp(0.8 * s[2] + 0.1, 0., 1.))
-        cdp = _with_interp(
+        colloc_cdp = _CollocationProblem(
             ContinuousDP(f, g, 0.9, shocks, weights, s -> 0., s -> 1.),
             Interp(basis))
-        n = cdp.interp.length
-        X = [0.25 + 0.25 * (cdp.interp.S[i, 1] + cdp.interp.S[i, 2])
+        n = colloc_cdp.interp.length
+        X = [0.25 + 0.25 * (colloc_cdp.interp.S[i, 1] +
+                            colloc_cdp.interp.S[i, 2])
              for i in 1:n]
         C = Vector{Float64}(undef, n)
-        evaluate_policy!(cdp, X, C)
-        @test C ≈ evaluate_policy_ref(cdp, X) rtol=1e-9
+        evaluate_policy!(colloc_cdp, X, C)
+        @test C ≈ evaluate_policy_ref(colloc_cdp, X) rtol=1e-9
     end
 end

--- a/test/test_foc.jl
+++ b/test/test_foc.jl
@@ -46,14 +46,15 @@ using QuantEcon: qnwlogn
         # Brent
         res = solve(cdp, CollocationSolver(basis; inner_solver=:foc),
                     verbose=0)
-        colloc_cdp = res.cdp
+        colloc_cdp = ContinuousDPs._colloc(res)
         ws = CDPWorkspace(colloc_cdp)
         foreach(dfec -> set_coefs!(dfec, res.C), ws.dfecs)
         for i in 1:colloc_cdp.interp.length
             s = colloc_cdp.interp.S[i]
-            v_foc, x_foc = _s_wise_max_foc!(colloc_cdp, s, res.C, ws.fec, ws.dfecs,
-                                            NaN)
-            v_brent, x_brent = _s_wise_max!(colloc_cdp, s, res.C, ws.fec)
+            v_foc, x_foc = _s_wise_max_foc!(colloc_cdp.cdp, s, res.C,
+                                            ws.fec, ws.dfecs, NaN)
+            v_brent, x_brent = _s_wise_max!(colloc_cdp.cdp, s, res.C,
+                                            ws.fec)
             @test v_foc ≈ v_brent rtol=1e-8
             @test x_foc ≈ x_brent atol=1e-6
         end
@@ -88,11 +89,11 @@ using QuantEcon: qnwlogn
         res = solve(cdp_c, CollocationSolver(Basis(ChebParams(10, 0.1, 2.0));
                                              inner_solver=:foc), verbose=0)
         @test res.converged
-        colloc_cdp = res.cdp
+        colloc_cdp = ContinuousDPs._colloc(res)
         ws = CDPWorkspace(colloc_cdp)
         foreach(dfec -> set_coefs!(dfec, res.C), ws.dfecs)
-        v, x = _s_wise_max_foc!(colloc_cdp, colloc_cdp.interp.S[1], res.C, ws.fec,
-                                ws.dfecs, NaN)
+        v, x = _s_wise_max_foc!(colloc_cdp.cdp, colloc_cdp.interp.S[1],
+                                res.C, ws.fec, ws.dfecs, NaN)
         @test x ≈ 1.0 atol=1e-6
     end
 
@@ -100,7 +101,7 @@ using QuantEcon: qnwlogn
         basis = Basis(LinParams(50, s_min, s_max))
         res = solve(cdp, CollocationSolver(basis), verbose=0)  # solves fine via Brent
         @test res.converged
-        ws = CDPWorkspace(res.cdp)  # inner_solver defaults to :foc
+        ws = CDPWorkspace(ContinuousDPs._colloc(res))  # inner_solver defaults to :foc
         @test ws.dfecs === nothing  # Lin basis: FOC unavailable
     end
 
@@ -108,7 +109,7 @@ using QuantEcon: qnwlogn
         basis = Basis(ChebParams(10, s_min, s_max))
         @test_throws ArgumentError CollocationSolver(basis;
                                                      inner_solver=:newton)
-        colloc_cdp = ContinuousDPs._with_interp(cdp, ContinuousDPs.Interp(basis))
+        colloc_cdp = ContinuousDPs._CollocationProblem(cdp, ContinuousDPs.Interp(basis))
         @test_throws ArgumentError CDPWorkspace(colloc_cdp, inner_solver=:bogus)
     end
 end

--- a/test/test_multidim_actions.jl
+++ b/test/test_multidim_actions.jl
@@ -60,7 +60,7 @@ using ContinuousDPs: CDPWorkspace
     actions = ContinuousActions{2}(x_lb2, x_ub2)
     cdp2 = ContinuousDP(f2c, g2c, beta, shocks, weights, actions)
     # Bound instance for tests of internal functions
-    colloc_cdp2 = ContinuousDPs._with_interp(cdp2, ContinuousDPs.Interp(basis))
+    colloc_cdp2 = ContinuousDPs._CollocationProblem(cdp2, ContinuousDPs.Interp(basis))
 
     S = nodes(basis)[1]
     v_star_on_S = v_star.(view(S, :, 1), view(S, :, 2))
@@ -159,7 +159,7 @@ using ContinuousDPs: CDPWorkspace
         fec = ContinuousDPs.FunEvalCache(basis)
         for i in (1, 40, 100)
             xout = fill(NaN, 2)
-            ContinuousDPs._s_wise_max_multi!(colloc_cdp2, S[i, :],
+            ContinuousDPs._s_wise_max_multi!(colloc_cdp2.cdp, S[i, :],
                                              res_b.C, fec, nothing, xout,
                                              false)
             @test xout == res_b.X[i, :]

--- a/test/test_solver_types.jl
+++ b/test/test_solver_types.jl
@@ -15,7 +15,8 @@ using QuantEcon: qnwlogn
         # Keyword form (canonical)
         cdp = ContinuousDP(f=f, g=g, discount=beta, shocks=shocks,
                            weights=weights, x_lb=x_lb, x_ub=x_ub)
-        @test cdp.interp === nothing
+        # A ContinuousDP holds primitives only
+        @test !(:interp in fieldnames(ContinuousDP))
         @test cdp.discount == beta
         @test cdp.actions isa ContinuousActions{1}
 
@@ -28,10 +29,10 @@ using QuantEcon: qnwlogn
         # Positional forms
         cdp_p = @inferred ContinuousDP(f, g, beta, shocks, weights, x_lb,
                                        x_ub)
-        @test cdp_p.interp === nothing
+        @test cdp_p isa ContinuousDP
         cdp_p2 = @inferred ContinuousDP(f, g, beta, shocks, weights,
                                         ContinuousActions(x_lb, x_ub))
-        @test cdp_p2.interp === nothing
+        @test cdp_p2 isa ContinuousDP
 
         # Exclusivity of `actions` and `x_lb`/`x_ub`
         @test_throws ArgumentError ContinuousDP(
@@ -53,10 +54,9 @@ using QuantEcon: qnwlogn
                                 actions=DiscreteActions(x_grid))
         @test cdp_disc.actions isa DiscreteActions
         @test cdp_disc.actions.vals == x_grid
-        @test cdp_disc.interp === nothing
 
-        # The state dimension is not known without a solver
-        @test_throws ArgumentError ndims(cdp)
+        # The state dimension is not defined without a solver
+        @test_throws MethodError ndims(cdp)
     end
 
     @testset "CollocationSolver construction" begin
@@ -107,9 +107,9 @@ using QuantEcon: qnwlogn
     @testset "solve with a solver object" begin
         res = @inferred solve(cdp, CollocationSolver(basis); verbose=0)
         @test res.converged
-        # The bound problem is stored in the result
-        @test res.cdp.interp !== nothing
-        @test ndims(res.cdp) == 1
+        # The problem and the interpolation scheme are stored in the result
+        @test res.cdp isa ContinuousDP
+        @test res.interp isa ContinuousDPs.Interp
         @test ndims(res) == 1
 
         # v_init length validation
@@ -149,29 +149,27 @@ using QuantEcon: qnwlogn
         # The solver's basis determines the approximation
         basis_b = Basis(ChebParams(12, s_min, s_max))
         res_b = solve(cdp, CollocationSolver(basis_b); verbose=0)
-        @test res_b.cdp.interp.basis === basis_b
+        @test res_b.interp.basis === basis_b
         @test length(res_b.C) == 12
     end
 
     @testset "copy constructor" begin
         # Primitives copy stays primitives
         cdp2 = @inferred ContinuousDP(cdp)
-        @test cdp2.interp === nothing
         @test cdp2.discount == cdp.discount
         @test cdp2.shocks == cdp.shocks
         @test cdp2.weights == cdp.weights
 
         cdp3 = ContinuousDP(cdp; discount=0.9)
         @test cdp3.discount == 0.9
-        @test cdp3.interp === nothing
 
         # The removed basis keyword is rejected
         @test_throws MethodError ContinuousDP(cdp; basis=basis)
 
-        # A copy of a solver-bound problem is primitives-only
+        # The problem stored in a result copies like any other
         res = solve(cdp, CollocationSolver(basis); verbose=0)
         cdp4 = ContinuousDP(res.cdp; discount=0.9)
-        @test cdp4.interp === nothing
+        @test cdp4 isa ContinuousDP
         @test cdp4.discount == 0.9
     end
 end

--- a/test/test_solver_types.jl
+++ b/test/test_solver_types.jl
@@ -119,8 +119,8 @@ using QuantEcon: qnwlogn
         # The removed v0.2 method form hits the instructive error stub
         @test_throws ArgumentError solve(cdp, PFI; verbose=0)
         @test_throws ArgumentError solve(cdp; verbose=0)
-        @test_throws r"was removed in v0.4" solve(cdp, PFI)
-        @test_throws r"was removed in v0.4" solve(cdp, LQA;
+        @test_throws r"has been removed" solve(cdp, PFI)
+        @test_throws r"has been removed" solve(cdp, LQA;
                                                   point=(1.0, 0.5, 1.0))
 
         # A solver is stateless: reuse across solves and problems gives
@@ -140,9 +140,9 @@ using QuantEcon: qnwlogn
         # The v0.2 basis-endowed forms hit the instructive error stubs
         # (the 7-arg form would otherwise silently match the primitives
         # `(..., x_lb, x_ub)` method)
-        @test_throws r"removed in v0\.4" ContinuousDP(
+        @test_throws r"have been removed" ContinuousDP(
             f, g, beta, shocks, weights, x_lb, x_ub, basis)
-        @test_throws r"removed in v0\.4" ContinuousDP(
+        @test_throws r"have been removed" ContinuousDP(
             f, g, beta, shocks, weights, ContinuousActions(x_lb, x_ub),
             basis)
 

--- a/test/test_solver_types.jl
+++ b/test/test_solver_types.jl
@@ -116,9 +116,12 @@ using QuantEcon: qnwlogn
         @test_throws ArgumentError solve(cdp, CollocationSolver(basis);
                                          v_init=zeros(3), verbose=0)
 
-        # A primitives-only problem cannot be solved without a solver
+        # The removed v0.2 method form hits the instructive error stub
         @test_throws ArgumentError solve(cdp, PFI; verbose=0)
         @test_throws ArgumentError solve(cdp; verbose=0)
+        @test_throws r"was removed in v0.4" solve(cdp, PFI)
+        @test_throws r"was removed in v0.4" solve(cdp, LQA;
+                                                  point=(1.0, 0.5, 1.0))
 
         # A solver is stateless: reuse across solves and problems gives
         # results identical to fresh solves (Interp is built per call)
@@ -133,51 +136,21 @@ using QuantEcon: qnwlogn
         @test res3.C != res1.C
     end
 
-    @testset "deprecated API agrees exactly with the new API" begin
-        cdp_old = @test_deprecated ContinuousDP(f, g, beta, shocks, weights,
-                                                x_lb, x_ub, basis)
-        @test cdp_old.interp !== nothing
-        @test ndims(cdp_old) == 1
-
-        for (algo, inner) in ((PFI, :foc), (VFI, :brent))
-            # The warning must recommend CollocationSolver for PFI/VFI
-            res_old = @test_deprecated r"CollocationSolver" solve(
-                cdp_old, algo; verbose=0, inner_solver=inner)
-            res_new = solve(cdp, CollocationSolver(basis; algorithm=algo,
-                                                   inner_solver=inner);
-                            verbose=0)
-            @test res_old.C == res_new.C
-            @test res_old.V == res_new.V
-            @test res_old.X == res_new.X
-            @test res_old.resid == res_new.resid
-        end
-
-        # LQA: old kwarg path vs LQASolver; the warning must recommend
-        # LQASolver (CollocationSolver rejects algorithm=LQA)
-        point = (1.0, 0.5, 1.0)
-        res_lqa_old = @test_deprecated r"LQASolver" solve(
-            cdp_old, LQA; point=point, verbose=0)
-        res_lqa_new = solve(cdp, LQASolver(basis; point=point); verbose=0)
-        @test res_lqa_old.C == res_lqa_new.C
-        @test res_lqa_old.V == res_lqa_new.V
-        @test res_lqa_old.X == res_lqa_new.X
-        @test res_lqa_old.resid == res_lqa_new.resid
-
-        # The explicitly supplied solver's basis wins over a basis stored
-        # by the deprecated constructor
-        basis_b = Basis(ChebParams(12, s_min, s_max))
-        res_b_old = solve(cdp_old, CollocationSolver(basis_b); verbose=0)
-        res_b_new = solve(cdp, CollocationSolver(basis_b); verbose=0)
-        @test res_b_old.cdp.interp.basis === basis_b
-        @test length(res_b_old.C) == 12
-        @test res_b_old.C == res_b_new.C
-        @test res_b_old.V == res_b_new.V
-
-        # Deprecated ActionSpace-and-basis form
-        cdp_old2 = @test_deprecated ContinuousDP(
+    @testset "removed basis-endowed constructors" begin
+        # The v0.2 basis-endowed forms hit the instructive error stubs
+        # (the 7-arg form would otherwise silently match the primitives
+        # `(..., x_lb, x_ub)` method)
+        @test_throws r"removed in v0\.4" ContinuousDP(
+            f, g, beta, shocks, weights, x_lb, x_ub, basis)
+        @test_throws r"removed in v0\.4" ContinuousDP(
             f, g, beta, shocks, weights, ContinuousActions(x_lb, x_ub),
             basis)
-        @test cdp_old2.interp !== nothing
+
+        # The solver's basis determines the approximation
+        basis_b = Basis(ChebParams(12, s_min, s_max))
+        res_b = solve(cdp, CollocationSolver(basis_b); verbose=0)
+        @test res_b.cdp.interp.basis === basis_b
+        @test length(res_b.C) == 12
     end
 
     @testset "copy constructor" begin
@@ -192,16 +165,13 @@ using QuantEcon: qnwlogn
         @test cdp3.discount == 0.9
         @test cdp3.interp === nothing
 
-        # An interp bound by the deprecated constructor is preserved
-        cdp_old = @test_deprecated ContinuousDP(f, g, beta, shocks, weights,
-                                                x_lb, x_ub, basis)
-        cdp4 = ContinuousDP(cdp_old; discount=0.9)
-        @test cdp4.interp !== nothing
-        @test cdp4.discount == 0.9
+        # The removed basis keyword is rejected
+        @test_throws MethodError ContinuousDP(cdp; basis=basis)
 
-        # The basis keyword is deprecated but functional
-        cdp5 = @test_deprecated ContinuousDP(cdp; basis=basis)
-        @test cdp5.interp !== nothing
-        @test ndims(cdp5) == 1
+        # A copy of a solver-bound problem is primitives-only
+        res = solve(cdp, CollocationSolver(basis); verbose=0)
+        cdp4 = ContinuousDP(res.cdp; discount=0.9)
+        @test cdp4.interp === nothing
+        @test cdp4.discount == 0.9
     end
 end

--- a/test/test_workspace.jl
+++ b/test/test_workspace.jl
@@ -58,8 +58,8 @@ end
 
     res = solve(cdp, CollocationSolver(basis), verbose=0)
     # Internal operators work on a problem with a bound interpolation
-    # scheme; the result stores one
-    colloc_cdp = res.cdp
+    # scheme; rebuild it from the result
+    colloc_cdp = ContinuousDPs._colloc(res)
     C0 = copy(res.C)
     n = colloc_cdp.interp.length
     ws = CDPWorkspace(colloc_cdp, inner_solver=:brent)


### PR DESCRIPTION
Completes the v0.3.0 API break in one release, dropping the originally planned deprecation cycle: the deprecated shims were never in a tagged release, and a registry scan confirms no registered package depends on ContinuousDPs, so no released user code relies on them.

## Removals

The basis-endowed `ContinuousDP` constructors, the `basis` keyword of the copy constructor, `solve(cdp, PFI/VFI/LQA; ...)`, and `ndims(::ContinuousDP)`. Error stubs with version-agnostic migration messages replace the removed methods; the 7-arg constructor stub is load-bearing beyond ergonomics — without it the removed `(..., actions, basis)` form would silently match the primitives `(..., x_lb, x_ub)` method and construct a nonsense action space.

## Internal refactor (zero behavior change)

`ContinuousDP` loses the transitional `interp` field and the `N` type parameter; the internal `_CollocationProblem{N}` pairs `(cdp, interp)` and is consumed by everything from the node-sweep level up, while the state-local point kernels keep the plain `ContinuousDP` (they are interpolation-free by design). `CDPSolveResult` stores `cdp` and `interp` as separate fields; `ValueFunction`/`PolicyFunction` read `res.interp`. Benchmarks and the optgrowth notebook migrate to the carrier type.

## Validation

Full suite green; the refactor was previously validated as a pure representation change at content-equivalent commits (byte-identical sweep allocations via worktree comparison; PkgBenchmark judge from a clean clone: zero regressions, three improvements on the `2d_spline_2ctrl` keys); post-condition greps for every transitional construct are empty; the functors remain zero-allocation on the new field path.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)