### PR TITLE
ENH, DOC: Validate the weights length at construction; document g-totality for discrete actions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,7 +122,7 @@ ALWAYS run these validation steps after making changes:
 
 ### Action spaces (`src/cdp.jl`)
 - `ContinuousDP` stores an `actions::ActionSpace`: `ContinuousActions(x_lb, x_ub)` (one-dimensional box; the legacy positional `x_lb, x_ub` constructor arguments wrap into this), `ContinuousActions{M}(x_lb, x_ub)` (M-dimensional box with length-M tuple- or vector-valued bounds; actions passed to `f`/`g` as length-M indexable collections; policies stored as `n x M` matrices), or `DiscreteActions(vals)` (finite set of action values of any homogeneous type).
-- Discrete actions follow the QuantEcon `MarkovChain`/`state_values` convention: solvers work with indices internally (`ws.X_ind`, `res.X_ind`); `res.X` exposes the corresponding values. The inner problem is solved by exact enumeration; `inner_solver` is ignored. Infeasible state-action pairs are expressed by `f` returning `-Inf`.
+- Discrete actions follow the QuantEcon `MarkovChain`/`state_values` convention: solvers work with indices internally (`ws.X_ind`, `res.X_ind`); `res.X` exposes the corresponding values. The inner problem is solved by exact enumeration; `inner_solver` is ignored. Infeasible state-action pairs are expressed by `f` returning `-Inf`, but `g` must remain evaluable at every pair: at all-infeasible nodes the stored fallback (first) action reaches `g` through policy evaluation.
 - `simulate` recomputes the greedy action exactly at each visited state for discrete actions (a discrete policy must not be interpolated); continuous actions keep policy interpolation.
 - LQA requires a continuous action space (`ArgumentError` otherwise).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,15 +46,14 @@ weights = [1.0]  # shock weights
 x_lb(s) = 0.01  # lower bound on action
 x_ub(s) = s - 0.01  # upper bound on action
 
-# Create basis for approximation
+# Create continuous DP from the model primitives (no basis here)
+cdp = ContinuousDP(f, g, discount, shocks, weights, x_lb, x_ub)
+
+# The solution methodology is specified by a solver object
 n = 10
 basis = Basis(ChebParams(n, s_min, s_max))
-
-# Create continuous DP
-cdp = ContinuousDP(f, g, discount, shocks, weights, x_lb, x_ub, basis)
-
-# Solve using PFI or VFI
-res = solve(cdp, PFI)  # or VFI
+solver = CollocationSolver(basis; algorithm=PFI)  # or algorithm=VFI
+res = solve(cdp, solver)
 
 # Simulate solution
 s_init = 1.0
@@ -122,7 +121,7 @@ ALWAYS run these validation steps after making changes:
 
 ### Action spaces (`src/cdp.jl`)
 - `ContinuousDP` stores an `actions::ActionSpace`: `ContinuousActions(x_lb, x_ub)` (one-dimensional box; the legacy positional `x_lb, x_ub` constructor arguments wrap into this), `ContinuousActions{M}(x_lb, x_ub)` (M-dimensional box with length-M tuple- or vector-valued bounds; actions passed to `f`/`g` as length-M indexable collections; policies stored as `n x M` matrices), or `DiscreteActions(vals)` (finite set of action values of any homogeneous type).
-- Discrete actions follow the QuantEcon `MarkovChain`/`state_values` convention: solvers work with indices internally (`ws.X_ind`, `res.X_ind`); `res.X` exposes the corresponding values. The inner problem is solved by exact enumeration; `inner_solver` is ignored. Infeasible state-action pairs are expressed by `f` returning `-Inf`, but `g` must remain evaluable at every pair: at all-infeasible nodes the stored fallback (first) action reaches `g` through policy evaluation.
+- Discrete actions follow the QuantEcon `MarkovChain`/`state_values` convention: solvers work with indices internally (`ws.X_ind`, `res.X_ind`); `res.X` exposes the corresponding values. The inner problem is solved by exact enumeration; `inner_solver` is ignored. Infeasible state-action pairs are expressed by `f` returning `-Inf`; the enumeration then skips `g` for that candidate. A well-posed model has at least one feasible action at every state the solver evaluates; if every action is infeasible at a node, the first action is retained as a fallback and later policy evaluation may call `g` for that pair (so `g` should tolerate it).
 - `simulate` recomputes the greedy action exactly at each visited state for discrete actions (a discrete policy must not be interpolated); continuous actions keep policy interpolation.
 - LQA requires a continuous action space (`ArgumentError` otherwise).
 
@@ -145,8 +144,8 @@ Candidate actions explored during the inner maximization can map the next state 
 ### Algorithm Types
 - **PFI (Policy Function Iteration)**: Generally faster convergence; per-iteration cost includes a collocation linear solve
 - **VFI (Value Function Iteration)**: More robust but potentially slower
-- **LQA (Linear Quadratic Approximation)**: Approximates the model around a steady state
-- All algorithms available through `solve()` with method parameter; `solve` also accepts `inner_solver=:foc` (default) or `:brent` for the inner maximization
+- **LQA (Linear Quadratic Approximation)**: Approximates the model around a reference point
+- PFI and VFI are selected with `CollocationSolver(basis; algorithm=PFI)` / `CollocationSolver(basis; algorithm=VFI)`; the inner maximizer with its `inner_solver` keyword (`:foc` default, `:brent` derivative-free); LQA with `LQASolver(basis; point=point)`. The solver object is passed to `solve(cdp, solver)`.
 
 ### Basis Types
 - **Chebyshev**: `ChebParams(n, s_min, s_max)` - good general purpose choice

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -8,16 +8,21 @@ which can be run standalone or through
 
 ## What is benchmarked
 
-The suite runs three model cases:
+The suite runs the following model cases:
 
 - `1d_cheb`: 1-D stochastic optimal growth, Chebyshev basis (50 nodes,
   9 shock nodes);
 - `1d_spline`: same model, cubic spline basis (101 nodes);
 - `2d_spline`: 2-D stochastic optimal growth with leisure
   (Santos, 1999, Sec. 7.3; same model as in `test/test_cdp_multidim.jl`),
-  quadratic spline basis (43 × 3 nodes, 7 shock nodes).
+  quadratic spline basis (43 × 3 nodes, 7 shock nodes);
+- `1d_cheb_discrete`: discrete-action variant of the 1-D model
+  (201 actions, solved by enumeration; `solve` and `bellman_operator`
+  keys only);
+- `2d_spline_2ctrl`: the Santos model in its original two-control
+  formulation (`solve` and `bellman_operator` keys only).
 
-For each case, the following are benchmarked:
+For the first three cases, the following are benchmarked:
 
 | Key | Description |
 |:----|:------------|

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -129,7 +129,9 @@ with the *indices* into `vals`, and the solution exposes both the values
 `MarkovChain`/`state_values` convention of QuantEcon.
 
 Infeasible state-action pairs are expressed by the reward function returning
-`-Inf`.
+`-Inf`. The transition function `g` must nevertheless remain evaluable at
+every such pair: at a state where *every* action is infeasible, the solvers
+store the first action as a fallback, and policy evaluation calls `g` there.
 
 # Fields
 
@@ -196,6 +198,16 @@ struct ContinuousDP{Tf,Tg,TR<:AbstractVecOrMat,TA<:ActionSpace}
     shocks::TR
     weights::Vector{Float64}
     actions::TA
+
+    # The explicit inner constructor suppresses the implicit outer one,
+    # which would otherwise be more specific than (and shadow) the
+    # validating positional constructor below whenever `discount` is
+    # already a Float64
+    function ContinuousDP{Tf,Tg,TR,TA}(
+            f, g, discount, shocks, weights, actions
+        ) where {Tf,Tg,TR<:AbstractVecOrMat,TA<:ActionSpace}
+        return new{Tf,Tg,TR,TA}(f, g, discount, shocks, weights, actions)
+    end
 end
 
 """
@@ -224,6 +236,9 @@ Give either `actions`, or both `x_lb` and `x_ub` (equivalent to
 function ContinuousDP(f, g, discount::Real,
                       shocks::AbstractVecOrMat, weights::Vector{Float64},
                       actions::ActionSpace)
+    length(weights) == size(shocks, 1) || throw(ArgumentError(
+        "`weights` must have one weight per shock node " *
+        "($(size(shocks, 1))); got $(length(weights))"))
     return ContinuousDP{typeof(f),typeof(g),typeof(shocks),typeof(actions)}(
         f, g, Float64(discount), shocks, weights, actions)
 end

--- a/src/cdp.jl
+++ b/src/cdp.jl
@@ -129,9 +129,12 @@ with the *indices* into `vals`, and the solution exposes both the values
 `MarkovChain`/`state_values` convention of QuantEcon.
 
 Infeasible state-action pairs are expressed by the reward function returning
-`-Inf`. The transition function `g` must nevertheless remain evaluable at
-every such pair: at a state where *every* action is infeasible, the solvers
-store the first action as a fallback, and policy evaluation calls `g` there.
+`-Inf`; the enumeration over actions then skips the transition evaluation
+for that candidate. A well-posed model should have at least one feasible
+action at every state the solver evaluates. If every action is infeasible
+at some state, the first action is retained as a fallback, and subsequent
+policy evaluation may call `g` for that pair — `g` should tolerate such
+calls.
 
 # Fields
 
@@ -187,7 +190,8 @@ and [`LQASolver`](@ref)).
 - `g::Tg`: State transition function `g(s, x, e)`.
 - `discount::Float64`: Discount factor.
 - `shocks::TR<:AbstractVecOrMat`: Discretized shock nodes.
-- `weights::Vector{Float64}`: Probability weights for the shock nodes.
+- `weights::Vector{Float64}`: Probability weights, one per shock node
+  (`length(weights) == size(shocks, 1)`).
 - `actions::TA<:ActionSpace`: Action space (see [`ContinuousActions`](@ref)
   and [`DiscreteActions`](@ref)).
 """
@@ -201,11 +205,15 @@ struct ContinuousDP{Tf,Tg,TR<:AbstractVecOrMat,TA<:ActionSpace}
 
     # The explicit inner constructor suppresses the implicit outer one,
     # which would otherwise be more specific than (and shadow) the
-    # validating positional constructor below whenever `discount` is
-    # already a Float64
+    # `discount::Real` positional constructor below whenever `discount`
+    # is already a Float64. The weights-length invariant lives here, the
+    # boundary every construction path must pass.
     function ContinuousDP{Tf,Tg,TR,TA}(
             f, g, discount, shocks, weights, actions
         ) where {Tf,Tg,TR<:AbstractVecOrMat,TA<:ActionSpace}
+        length(weights) == size(shocks, 1) || throw(ArgumentError(
+            "`weights` must have one weight per shock node " *
+            "($(size(shocks, 1))); got $(length(weights))"))
         return new{Tf,Tg,TR,TA}(f, g, discount, shocks, weights, actions)
     end
 end
@@ -231,14 +239,12 @@ Give either `actions`, or both `x_lb` and `x_ub` (equivalent to
   (lower and upper bound of the action as functions of the state) for a
   one-dimensional continuous action space.
 - `shocks::AbstractVecOrMat`: Discretized shock nodes.
-- `weights::Vector{Float64}`: Probability weights for the shock nodes.
+- `weights::Vector{Float64}`: Probability weights, one per shock node
+  (`length(weights) == size(shocks, 1)`).
 """
 function ContinuousDP(f, g, discount::Real,
                       shocks::AbstractVecOrMat, weights::Vector{Float64},
                       actions::ActionSpace)
-    length(weights) == size(shocks, 1) || throw(ArgumentError(
-        "`weights` must have one weight per shock node " *
-        "($(size(shocks, 1))); got $(length(weights))"))
     return ContinuousDP{typeof(f),typeof(g),typeof(shocks),typeof(actions)}(
         f, g, Float64(discount), shocks, weights, actions)
 end

--- a/test/test_solver_types.jl
+++ b/test/test_solver_types.jl
@@ -58,10 +58,21 @@ using QuantEcon: qnwlogn
         # The state dimension is not defined without a solver
         @test_throws MethodError ndims(cdp)
 
-        # weights must have one entry per shock node
+        # weights must have one entry per shock node, on every
+        # construction path: keyword, positional (with a Float64 discount,
+        # the case the implicit outer constructor used to shadow), copy,
+        # and explicit-parametric (enforced by the inner constructor)
         @test_throws r"one weight per shock node" ContinuousDP(
             f=f, g=g, discount=beta, shocks=shocks, weights=[0.5, 0.5],
             x_lb=x_lb, x_ub=x_ub)
+        @test_throws r"one weight per shock node" ContinuousDP(
+            f, g, beta, shocks, [0.5, 0.5], x_lb, x_ub)
+        @test_throws r"one weight per shock node" ContinuousDP(
+            cdp; weights=[0.5, 0.5])
+        acts = ContinuousActions(x_lb, x_ub)
+        @test_throws r"one weight per shock node" ContinuousDP{
+            typeof(f),typeof(g),typeof(shocks),typeof(acts)}(
+            f, g, beta, shocks, [0.5, 0.5], acts)
     end
 
     @testset "CollocationSolver construction" begin

--- a/test/test_solver_types.jl
+++ b/test/test_solver_types.jl
@@ -57,6 +57,11 @@ using QuantEcon: qnwlogn
 
         # The state dimension is not defined without a solver
         @test_throws MethodError ndims(cdp)
+
+        # weights must have one entry per shock node
+        @test_throws r"one weight per shock node" ContinuousDP(
+            f=f, g=g, discount=beta, shocks=shocks, weights=[0.5, 0.5],
+            x_lb=x_lb, x_ub=x_ub)
     end
 
     @testset "CollocationSolver construction" begin


### PR DESCRIPTION
Small pre-v0.3.0 hygiene items surfaced while validating the upcoming transition-kernel work; none change any correctly-specified model's behavior.

## Weights-length validation (ENH)

Constructing a `ContinuousDP` whose `weights` vector's length differs from the number of shock nodes previously failed only deep inside `solve`, as an obscure `BoundsError`; construction now throws an informative `ArgumentError`. Per review, the invariant is enforced in the **inner constructor** — the boundary every construction path must pass, including the explicit-parametric form — with regression tests for the keyword, positional, copy, and explicit-parametric paths.

The explicit inner constructor also suppresses the *implicit* outer constructor, which (being fully concrete) is more specific than the `discount::Real` method whenever the discount is already a `Float64` and would otherwise shadow it. (Latent until now: with no validation to bypass, the constructors were behaviorally identical.)

## Documentation (DOC)

- `DiscreteActions`: infeasible state-action pairs are expressed by `f` returning `-Inf`, and the enumeration skips `g` for such candidates; a well-posed model has at least one feasible action at every evaluated state, and at all-infeasible nodes the retained first-action fallback may reach `g` through policy evaluation (documented as an implementation behavior `g` should tolerate, not a totality requirement). Stated in the docstring and the agent instructions.
- Agent instructions: the "basic workflow" example and the algorithm summary still showed the removed v0.2 API (basis-endowed constructor, `solve(cdp, PFI)`, `solve`-level `inner_solver`); updated to the solver-object API.
- `benchmark/README.md`: the model-case list predated the `1d_cheb_discrete` and `2d_spline_2ctrl` suite additions; both are now listed.

## Validation

Full test suite green, including a new constructor-validation test exercising the previously-shadowed keyword path.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)
