### PR TITLE
MAINT: Route the expectation loops through an internal _QuadratureKernel

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -125,6 +125,11 @@ ALWAYS run these validation steps after making changes:
 - `simulate` recomputes the greedy action exactly at each visited state for discrete actions (a discrete policy must not be interpolated); continuous actions keep policy interpolation.
 - LQA requires a continuous action space (`ArgumentError` otherwise).
 
+### Transition kernel (`src/transition_kernel.jl`)
+- The internal `_QuadratureKernel` (constructed per call via `_kernel(cdp)`, a free non-escaping bundle of `g`, `shocks`, `weights`) represents the transition kernel as finitely many weighted next-state branches per `(s, x)`. Every expectation loop routes through its primitives: `_branch_weights(ker, s, x)` (weight container, fetched once per `(s, x)`), `_branch_state(ker, s, x, j)` (next state on branch `j`; derivative-based consumers re-evaluate it at perturbed actions holding `j` fixed), and `_expected_value` (plain weighted sum of interpolant values). Do not write raw `for j in eachindex(cdp.weights)` expectation loops in new code.
+- Exceptions by design: `simulate!` samples shocks directly (sampling, not expectation) and LQA uses the fields directly.
+- The structured path must stay zero-allocation; the routing was validated bit-identical and allocation-byte-identical against the pre-kernel code.
+
 ### Solver workspace and inner solvers (`src/cdp.jl`, `src/inner_solvers.jl`, `src/policy_system.jl`)
 - `CDPWorkspace(cp::_CollocationProblem; inner_solver=:foc)` holds all preallocated buffers and evaluation caches; it is created once per `solve`. Workspaces and caches are NOT thread-safe (one per thread).
 - The inner maximization over actions uses the first-order condition by default (`inner_solver=:foc`): for scalar actions, safeguarded root-finding on H'; for M-dimensional actions, box-constrained LBFGS with the analytic gradient (exact interpolant gradients, finite differences of user `f`/`g`, evaluation points clamped into the box). Automatic fallback to the derivative-free path per basis (piecewise linear bases), per state (non-finite values, exceptions), and per call (`inner_solver=:brent`): Brent for scalar actions, cyclic coordinate-wise Brent for M-dimensional ones. Warm starts live in `ws.X`.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -54,6 +54,7 @@ approx_lq
 Modules = [ContinuousDPs]
 Pages   = [
     "cdp.jl",
+    "transition_kernel.jl",
     "inner_solvers.jl",
     "policy_system.jl",
     "lq_approx.jl",

--- a/src/ContinuousDPs.jl
+++ b/src/ContinuousDPs.jl
@@ -12,6 +12,7 @@ const DPAlgorithm = DDPAlgorithm
 
 include("point_eval.jl")
 include("cdp.jl")
+include("transition_kernel.jl")
 include("inner_solvers.jl")
 include("policy_system.jl")
 include("lq_approx.jl")

--- a/src/inner_solvers.jl
+++ b/src/inner_solvers.jl
@@ -25,13 +25,9 @@ function _s_wise_max!(cdp::ContinuousDP, s, C, fec::FunEvalCache)
     cdp.actions isa ContinuousActions || throw(ArgumentError(
         "Brent maximization requires a continuous action space; discrete " *
         "action spaces are solved by enumeration"))
+    ker = _kernel(cdp)
     function objective(x)
-        cont = 0.0
-        for j in eachindex(cdp.weights)
-            e = _row(cdp.shocks, j)
-            s_next = cdp.g(s, x, e)
-            cont += cdp.weights[j] * funeval_point!(fec, C, s_next)
-        end
+        cont = _expected_value(ker, fec, C, s, x)
         flow = cdp.f(s, x)
         return flow + cdp.discount * cont
     end
@@ -49,11 +45,7 @@ end
 function _objective(cdp::ContinuousDP, s, C, fec::FunEvalCache, x)
     flow = cdp.f(s, x)
     isfinite(flow) || return flow
-    cont = 0.0
-    for j in eachindex(cdp.weights)
-        e = _row(cdp.shocks, j)
-        cont += cdp.weights[j] * funeval_point!(fec, C, cdp.g(s, x, e))
-    end
+    cont = _expected_value(_kernel(cdp), fec, C, s, x)
     return flow + cdp.discount * cont
 end
 
@@ -124,18 +116,18 @@ function _objective_and_deriv(cdp::ContinuousDP, s, C, fec::FunEvalCache,
     h > eps() * max(abs(x), 1.0) || return NaN, NaN
     f0 = cdp.f(s, x)
     fp = (cdp.f(s, x + h) - cdp.f(s, x - h)) / (2h)
+    ker = _kernel(cdp)
+    w = _branch_weights(ker, s, x)
     cont = 0.0
     contp = 0.0
-    for j in eachindex(cdp.weights)
-        e = _row(cdp.shocks, j)
-        s_next = cdp.g(s, x, e)
-        s_up = cdp.g(s, x + h, e)
-        s_dn = cdp.g(s, x - h, e)
+    for j in eachindex(w)
+        s_next = _branch_state(ker, s, x, j)
+        s_up = _branch_state(ker, s, x + h, j)
+        s_dn = _branch_state(ker, s, x - h, j)
         v = funeval_point!(fec, C, s_next)
         dv = _grad_dot_gx(dfecs, s_next, s_up, s_dn, h)
-        w = cdp.weights[j]
-        cont += w * v
-        contp += w * dv
+        cont += w[j] * v
+        contp += w[j] * dv
     end
     H = f0 + cdp.discount * cont
     Hp = fp + cdp.discount * contp
@@ -302,12 +294,10 @@ function _negH_multi!(G, cdp::ContinuousDP, s, C, fec::FunEvalCache{N},
         return -flow  # +Inf (or NaN): Optim sees an infeasible point
     end
 
+    ker = _kernel(cdp)
+
     if G === nothing
-        cont = 0.0
-        for j in eachindex(cdp.weights)
-            e = _row(cdp.shocks, j)
-            cont += cdp.weights[j] * funeval_point!(fec, C, cdp.g(s, xt, e))
-        end
+        cont = _expected_value(ker, fec, C, s, xt)
         return -(flow + cdp.discount * cont)
     end
 
@@ -330,25 +320,26 @@ function _negH_multi!(G, cdp::ContinuousDP, s, C, fec::FunEvalCache{N},
         G[d] = (fu - fl) / (2 * h[d])
     end
 
+    w = _branch_weights(ker, s, xt)
     cont = 0.0
-    for j in eachindex(cdp.weights)
-        e = _row(cdp.shocks, j)
-        w = cdp.weights[j]
-        s_next = cdp.g(s, xt, e)
-        cont += w * funeval_point!(fec, C, s_next)
-        # grad V^(s_next), evaluated once per shock
+    for j in eachindex(w)
+        s_next = _branch_state(ker, s, xt, j)
+        cont += w[j] * funeval_point!(fec, C, s_next)
+        # grad V^(s_next), evaluated once per branch
         gradv = ntuple(nd -> funeval_point!(dfecs[nd], s_next), Val(N))
         for d in 1:M
-            s_up = cdp.g(s, ntuple(k -> k == d ? xt[k] + h[d] : xt[k],
-                                   Val(M)), e)
-            s_dn = cdp.g(s, ntuple(k -> k == d ? xt[k] - h[d] : xt[k],
-                                   Val(M)), e)
+            s_up = _branch_state(ker, s,
+                                 ntuple(k -> k == d ? xt[k] + h[d] : xt[k],
+                                        Val(M)), j)
+            s_dn = _branch_state(ker, s,
+                                 ntuple(k -> k == d ? xt[k] - h[d] : xt[k],
+                                        Val(M)), j)
             dv = 0.0
             for nd in 1:N
                 dv += gradv[nd] *
                       ((_coord(s_up, nd) - _coord(s_dn, nd)) / (2 * h[d]))
             end
-            G[d] += cdp.discount * w * dv
+            G[d] += cdp.discount * w[j] * dv
         end
     end
 

--- a/src/policy_system.jl
+++ b/src/policy_system.jl
@@ -26,15 +26,16 @@ end
 function _policy_system_lu(Phi::AbstractMatrix, cp::_CollocationProblem,
                            X, fec)
     cdp, ss = cp.cdp, cp.interp.S
+    ker = _kernel(cdp)
     n = size(ss, 1)
     A = copyto!(Matrix{Float64}(undef, n, n), Phi)
     for i in 1:n
         s = _row(ss, i)
-        for j in eachindex(cdp.weights)
-            e = _row(cdp.shocks, j)
-            s_next = cdp.g(s, _row(X, i), e)
-            _sub_basis_row!(A, i, fec, s_next,
-                            cdp.discount * cdp.weights[j])
+        x = _row(X, i)
+        w = _branch_weights(ker, s, x)
+        for j in eachindex(w)
+            s_next = _branch_state(ker, s, x, j)
+            _sub_basis_row!(A, i, fec, s_next, cdp.discount * w[j])
         end
     end
     return lu!(A)
@@ -69,14 +70,16 @@ end
 function _policy_system_lu(Phi::SparseMatrixCSC, cp::_CollocationProblem,
                            X, fec)
     cdp, ss = cp.cdp, cp.interp.S
+    ker = _kernel(cdp)
     n = size(ss, 1)
     Is, Js, Vs = Int[], Int[], Float64[]
     for i in 1:n
         s = _row(ss, i)
-        for j in eachindex(cdp.weights)
-            e = _row(cdp.shocks, j)
-            s_next = cdp.g(s, _row(X, i), e)
-            _append_basis_row!(Is, Js, Vs, i, fec, s_next, cdp.weights[j])
+        x = _row(X, i)
+        w = _branch_weights(ker, s, x)
+        for j in eachindex(w)
+            s_next = _branch_state(ker, s, x, j)
+            _append_basis_row!(Is, Js, Vs, i, fec, s_next, w[j])
         end
     end
     E = sparse(Is, Js, Vs, n, n)  # sums duplicate entries

--- a/src/transition_kernel.jl
+++ b/src/transition_kernel.jl
@@ -1,0 +1,43 @@
+"""
+    _QuadratureKernel{TG,TR}
+
+Internal representation of the transition kernel of a `ContinuousDP`: the
+distribution of the next state given `(s, x)`, as finitely many weighted
+branches `(s'_j, w_j)`. This structured kernel pairs the transition
+function `g` with fixed quadrature nodes and weights; branch `j` has next
+state `g(s, x, shocks[j])` and weight `weights[j]`.
+
+Consumers iterate branches by index: fetch the weight container once per
+`(s, x)` with `_branch_weights` and evaluate next states with
+`_branch_state`; derivative-based consumers re-evaluate `_branch_state`
+at perturbed actions holding the branch index fixed. The plain expected
+value of an interpolant is provided by `_expected_value`.
+"""
+struct _QuadratureKernel{TG,TR<:AbstractVecOrMat}
+    g::TG
+    shocks::TR
+    weights::Vector{Float64}
+end
+
+# Construction is free (a non-escaping bundle of references): callers may
+# construct per call rather than threading a kernel through signatures.
+_kernel(cdp::ContinuousDP) = _QuadratureKernel(cdp.g, cdp.shocks, cdp.weights)
+
+# Branch weights at (s, x), as an indexable collection aligned with the
+# branch indices. Fixed quadrature weights ignore (s, x).
+_branch_weights(ker::_QuadratureKernel, s, x) = ker.weights
+
+# Next state on branch j at (s, x)
+_branch_state(ker::_QuadratureKernel, s, x, j::Int) =
+    ker.g(s, x, _row(ker.shocks, j))
+
+# E[V^(s')] under the kernel at (s, x), where V^ is the interpolant with
+# coefficients C evaluated through fec
+function _expected_value(ker::_QuadratureKernel, fec::FunEvalCache, C, s, x)
+    w = _branch_weights(ker, s, x)
+    cont = 0.0
+    for j in eachindex(w)
+        cont += w[j] * funeval_point!(fec, C, _branch_state(ker, s, x, j))
+    end
+    return cont
+end


### PR DESCRIPTION
First of the transition-kernel PRs for the v0.3.1 line (design of record: the "General mechanism" section of #110 and the strategy-1 analysis in #89). Zero behavior change; the structured quadrature case compiles back to exactly the previous code.

## What it does

Introduces `src/transition_kernel.jl`: the internal `_QuadratureKernel(g, shocks, weights)` represents the transition kernel as finitely many weighted next-state branches per `(s, x)`, with three primitives:

- `_branch_weights(ker, s, x)` — the weight container, fetched once per `(s, x)`;
- `_branch_state(ker, s, x, j)` — the next state on branch `j`; derivative-based consumers re-evaluate it at perturbed actions holding the branch index fixed (this is what keeps the FOC finite-difference paths expressible for future kernels);
- `_expected_value` — the plain weighted interpolant sum.

Every expectation loop routes through them: the Brent objective closure, `_objective`, `_objective_and_deriv` (including the FOC branch derivatives), both `_negH_multi!` branches (`inner_solvers.jl`), and the dense and sparse `_policy_system_lu` assemblies (`policy_system.jl`). `simulate!`'s shock sampling and LQA stay on direct field access by design. `cdp.jl` is untouched.

In this PR the kernel is constructed per consumer call by `_kernel(cdp)` — free, a non-escaping bundle of references to fixed problem fields. The next PR in the stack (#118) moves construction to the sweep level (`_build_kernel` once per sweep-level entry point, the kernel passed to the per-state solvers as an argument) at the point where construction stops being free — callable weights are arity-probed there.

## Why

Groundwork for state- and action-dependent shock distributions (#110, next PR in the stack) and for the POMDPs generic-model adapter (#89): both need the expectation loops to be expressed against a kernel interface rather than against `(g, shocks, weights)` field access.

## Validation

- Full test suite green.
- Bit-identity: solve results identical (`==` on `C`/`V`/`X`) to the pre-kernel code on 14 configurations (scalar Chebyshev/spline x PFI/VFI x `:foc`/`:brent`, discrete actions, 2-D-state/2-D-action), via a worktree comparison harness.
- Sweep allocations byte-identical on the scalar and discrete paths; the M > 1 path shows only its known +-64-byte run-to-run jitter (present on both sides of the comparison).
- PkgBenchmark judge from a clean clone (content-equivalent commits; later restacks changed only validation/doc lines): zero regressions, all memory ratios 1.00; one formal improvement (`1d_cheb/evaluate_policy`, 0.92) from hoisting the policy row and weight container out of the assembly branch loop. An earlier judge against the pre-split base showed the same keys leaning improvement up to ~6-8%.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5)